### PR TITLE
Fix recap command flag check

### DIFF
--- a/Input v16.0.7b-hotfix3.patched.txt
+++ b/Input v16.0.7b-hotfix3.patched.txt
@@ -50,18 +50,18 @@ LC.lcSetFlag("isCmd", true);
     
     // быстрые ответы на оффер recap
     if (cmd === "/да")   {
-      if (!(typeof LC !== 'undefined' && LC.lcGet && wantRecap)) { try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){} return { text: "", stop: true }; }
+      if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) { try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){} return { text: "", stop: true }; }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn;
       LC.lcSetFlag("doRecap", true);
       return reply("📋 Recap will be generated.");
     }
     if (cmd === "/нет")  {
-      if (!(typeof LC !== 'undefined' && LC.lcGet && wantRecap)) { try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){} return { text: "", stop: true }; }
+      if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) { try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){} return { text: "", stop: true }; }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn + 5; L.lastRecapTurn = L.turn;
       return reply("🚫 Recap postponed for 5 turns.");
     }
     if (cmd === "/позже"){
-      if (!(typeof LC !== 'undefined' && LC.lcGet && wantRecap)) { try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){} return { text: "", stop: true }; }
+      if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) { try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){} return { text: "", stop: true }; }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn + 3; if (L.tm) L.tm.wantRecapTurn = 0;
       return reply("🕑 Recap later (3 turns).");
     }


### PR DESCRIPTION
## Summary
- ensure recap quick response commands verify the wantRecap flag using lcGetFlag
- keep recap offer commands clearing the flag and performing expected actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dad4c9dba483299a5da0f70fc49965