### PR TITLE
Filter recap turns when rewinding

### DIFF
--- a/Library v16.0.7b-hotfix3.patched.txt
+++ b/Library v16.0.7b-hotfix3.patched.txt
@@ -993,7 +993,14 @@ function turnSet(n) {
   L.epochDraft = null;
   L.prevOutput = "";
   L.lastOutput = "";
-  
+
+  if (L.tm && Array.isArray(L.tm.recapTurns)) {
+    L.tm.recapTurns = L.tm.recapTurns.filter(t => Number(t) < v);
+  }
+  if (L.tm && Number(L.tm.wantRecapTurn) >= v) {
+    L.tm.wantRecapTurn = 0;
+  }
+
       // clear flags on rewind
     LC.lcSetFlag("wantRecap", false);
     LC.lcSetFlag("doRecap", false);


### PR DESCRIPTION
## Summary
- clear stored recap turns that are no longer valid after rewinding the turn counter
- reset the requested recap turn if it would occur before the new turn

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dae6ac6b1883299814a24bb5c0b293