### PR TITLE
Ensure turn rewind tracks last recap turn

### DIFF
--- a/Library v16.0.7b-hotfix3.patched.txt
+++ b/Library v16.0.7b-hotfix3.patched.txt
@@ -995,7 +995,13 @@ function turnSet(n) {
   L.lastOutput = "";
 
   if (L.tm && Array.isArray(L.tm.recapTurns)) {
-    L.tm.recapTurns = L.tm.recapTurns.filter(t => Number(t) < v);
+    const recapTurns = L.tm.recapTurns
+      .map(t => Number(t))
+      .filter(t => Number.isFinite(t) && t < v)
+      .sort((a, b) => a - b);
+    L.tm.recapTurns = recapTurns;
+    const last = recapTurns.length ? recapTurns[recapTurns.length - 1] : -Infinity;
+    L.lastRecapTurn = Number.isFinite(last) ? last : 0;
   }
   if (L.tm && Number(L.tm.wantRecapTurn) >= v) {
     L.tm.wantRecapTurn = 0;


### PR DESCRIPTION
## Summary
- normalize recap turn history on rewind to keep values below the new turn
- update the tracked last recap turn to the latest recap prior to the rewind

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68daefa768f08329bc98a514215972d2