### PR TITLE
Improve evergreen character alias normalization

### DIFF
--- a/Library v16.0.7b-hotfix3.patched.txt
+++ b/Library v16.0.7b-hotfix3.patched.txt
@@ -637,7 +637,62 @@ L.debugMode = toBool(L.debugMode, false);
           "ковальски":"Директор Ковальски","kovalski":"Директор Ковальски","директор":"Директор Ковальски","александр":"Директор Ковальски"
         };
         const low = n.toLowerCase();
-        return aliases[low] || (n.charAt(0).toUpperCase() + n.slice(1));
+        const aliasIndex = { ...aliases };
+
+        const L = LC.lcInit ? LC.lcInit() : null;
+        const displayMap = {
+          "максим":"Максим",
+          "хлоя":"Хлоя",
+          "эшли":"Эшли",
+          "миссис грейсон":"Миссис Грейсон",
+          "директор ковальски":"Директор Ковальски"
+        };
+
+        if (L && L.aliases){
+          for (const key in L.aliases){
+            const canon = String(key || "").trim();
+            if (!canon) continue;
+            displayMap[canon.toLowerCase()] = canon;
+          }
+        }
+
+        function canonDisplay(str){
+          if (!str) return "";
+          if (displayMap[str]) return displayMap[str];
+          let out = str;
+          try {
+            out = str.replace(/\b\p{Ll}/gu, m => m.toUpperCase());
+          } catch(e) {
+            const words = str.split(/\s+/).filter(Boolean);
+            out = words.map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+          }
+          displayMap[str] = out;
+          return out;
+        }
+
+        const aliasMap = LC.getAliasMap ? LC.getAliasMap() : {};
+        for (const canon in aliasMap){
+          const canonLow = canon.toLowerCase();
+          const target = canonDisplay(canonLow);
+          const list = aliasMap[canon] || [];
+          for (let i=0;i<list.length;i++){
+            const item = String(list[i] || "").trim().toLowerCase();
+            if (!item) continue;
+            if (!aliasIndex[item]) aliasIndex[item] = target;
+          }
+          if (!aliasIndex[canonLow]) aliasIndex[canonLow] = target;
+        }
+
+        if (aliasIndex[low]) return aliasIndex[low];
+
+        const tokens = low.split(/\s+/).filter(Boolean);
+        for (let i=0;i<tokens.length;i++){
+          const token = tokens[i];
+          const canon = aliasIndex[token];
+          if (canon) return canon;
+        }
+
+        return n;
       },
       isImportantCharacter(name){
         const core = ["Максим","Хлоя","Эшли","Миссис Грейсон","Директор Ковальски","Maxim","Chloe","Ashley"];


### PR DESCRIPTION
## Summary
- expand evergreen character normalization to consult alias maps and tokenized names so multi-word mentions map to canonical forms
- fall back to the original capitalization when no alias match is found to avoid unintended casing changes

## Testing
- node - <<'NODE'
  global.state = {};
  const fs = require('fs');
  const vm = require('vm');
  const code = fs.readFileSync('Library v16.0.7b-hotfix3.patched.txt', 'utf8');
  vm.runInThisContext(code);
  
  const names = ['Максим Бергман', 'Хлоя Харпер'];
  for (const name of names){
    const canon = LC.autoEvergreen.normalizeCharName(name);
    console.log(name, '->', canon, 'important:', LC.autoEvergreen.isImportantCharacter(canon));
  }
  
  const samples = [
    'Максим Бергман и Хлоя Харпер теперь вместе.',
    'Хлоя Харпер теперь капитан команды.'
  ];
  
  samples.forEach((line, idx) => {
    const L = LC.lcInit();
    L.turn = idx + 1;
    LC.autoEvergreen.analyze(line, 'new');
  });
  
  const L = LC.lcInit();
  console.log('Evergreen relations:', L.evergreen.relations);
  console.log('Evergreen status:', L.evergreen.status);
  NODE

------
https://chatgpt.com/codex/tasks/task_b_68daf3593af4832993c45352b26ba32b