### PR TITLE
Handle recap quick replies without active offer

### DIFF
--- a/Input v16.0.7b-hotfix3.patched.txt
+++ b/Input v16.0.7b-hotfix3.patched.txt
@@ -50,18 +50,30 @@ LC.lcSetFlag("isCmd", true);
     
     // быстрые ответы на оффер recap
     if (cmd === "/да")   {
-      if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) { try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){} return { text: "", stop: true }; }
+      if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) {
+        try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){}
+        LC.lcSetFlag("isCmd", false);
+        return reply("ℹ️ Нет активного оффера рекапа.");
+      }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn;
       LC.lcSetFlag("doRecap", true);
       return reply("📋 Recap will be generated.");
     }
     if (cmd === "/нет")  {
-      if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) { try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){} return { text: "", stop: true }; }
+      if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) {
+        try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){}
+        LC.lcSetFlag("isCmd", false);
+        return reply("ℹ️ Нет активного оффера рекапа.");
+      }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn + 5; L.lastRecapTurn = L.turn;
       return reply("🚫 Recap postponed for 5 turns.");
     }
     if (cmd === "/позже"){
-      if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) { try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){} return { text: "", stop: true }; }
+      if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) {
+        try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){}
+        LC.lcSetFlag("isCmd", false);
+        return reply("ℹ️ Нет активного оффера рекапа.");
+      }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn + 3; if (L.tm) L.tm.wantRecapTurn = 0;
       return reply("🕑 Recap later (3 turns).");
     }


### PR DESCRIPTION
## Summary
- reset the command flag before exiting when recap quick replies have no active offer
- send an informational reply for /да, /нет, and /позже when no recap offer is active
- keep existing behavior unchanged when a recap offer is active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db977a66388329a5fb6dae46e6a2f4