### PR TITLE
Respect user-defined canons in evergreen alias normalization

### DIFF
--- a/Library v16.0.7b-hotfix3.patched.txt
+++ b/Library v16.0.7b-hotfix3.patched.txt
@@ -676,11 +676,15 @@ L.debugMode = toBool(L.debugMode, false);
           "директор ковальски":"Директор Ковальски"
         };
 
+        const userCanonSet = new Set();
+
         if (L && L.aliases){
           for (const key in L.aliases){
             const canon = String(key || "").trim();
             if (!canon) continue;
-            displayMap[canon.toLowerCase()] = canon;
+            const canonLow = canon.toLowerCase();
+            userCanonSet.add(canonLow);
+            displayMap[canonLow] = canon;
           }
         }
 
@@ -701,14 +705,19 @@ L.debugMode = toBool(L.debugMode, false);
         const aliasMap = LC.getAliasMap ? LC.getAliasMap() : {};
         for (const canon in aliasMap){
           const canonLow = canon.toLowerCase();
+          const isUserCanon = userCanonSet.has(canonLow);
           const target = canonDisplay(canonLow);
           const list = aliasMap[canon] || [];
           for (let i=0;i<list.length;i++){
             const item = String(list[i] || "").trim().toLowerCase();
             if (!item) continue;
-            if (!aliasIndex[item]) aliasIndex[item] = target;
+            if (isUserCanon || !Object.prototype.hasOwnProperty.call(aliasIndex, item)) {
+              aliasIndex[item] = target;
+            }
           }
-          if (!aliasIndex[canonLow]) aliasIndex[canonLow] = target;
+          if (isUserCanon || !Object.prototype.hasOwnProperty.call(aliasIndex, canonLow)) {
+            aliasIndex[canonLow] = target;
+          }
         }
 
         if (aliasIndex[low]) return aliasIndex[low];


### PR DESCRIPTION
## Summary
- track user-defined canonical names when normalizing evergreen character aliases
- update alias index entries for user canons while leaving built-in defaults untouched
- preserve the user-provided casing for canonical names during lookup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dba76a7920832997061e8adc5f4d97