### PR TITLE
Ensure recap quick replies remain command responses

### DIFF
--- a/Input v16.0.7b-hotfix3.patched.txt
+++ b/Input v16.0.7b-hotfix3.patched.txt
@@ -52,8 +52,12 @@ LC.lcSetFlag("isCmd", true);
     if (cmd === "/да")   {
       if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) {
         try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){}
-        LC.lcSetFlag("isCmd", false);
-        return reply("ℹ️ Нет активного оффера рекапа.");
+        return {
+          text: (LC.CONFIG?.CMD_PLACEHOLDER !== undefined)
+            ? LC.CONFIG.CMD_PLACEHOLDER
+            : "⟦SYS⟧ Нет активного оффера рекапа.",
+          stop: true
+        };
       }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn;
       LC.lcSetFlag("doRecap", true);
@@ -62,8 +66,12 @@ LC.lcSetFlag("isCmd", true);
     if (cmd === "/нет")  {
       if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) {
         try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){}
-        LC.lcSetFlag("isCmd", false);
-        return reply("ℹ️ Нет активного оффера рекапа.");
+        return {
+          text: (LC.CONFIG?.CMD_PLACEHOLDER !== undefined)
+            ? LC.CONFIG.CMD_PLACEHOLDER
+            : "⟦SYS⟧ Нет активного оффера рекапа.",
+          stop: true
+        };
       }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn + 5; L.lastRecapTurn = L.turn;
       return reply("🚫 Recap postponed for 5 turns.");
@@ -71,8 +79,12 @@ LC.lcSetFlag("isCmd", true);
     if (cmd === "/позже"){
       if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) {
         try { LC.lcSys('ℹ️ Нет активного оффера рекапа.'); } catch(_){}
-        LC.lcSetFlag("isCmd", false);
-        return reply("ℹ️ Нет активного оффера рекапа.");
+        return {
+          text: (LC.CONFIG?.CMD_PLACEHOLDER !== undefined)
+            ? LC.CONFIG.CMD_PLACEHOLDER
+            : "⟦SYS⟧ Нет активного оффера рекапа.",
+          stop: true
+        };
       }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn + 3; if (L.tm) L.tm.wantRecapTurn = 0;
       return reply("🕑 Recap later (3 turns).");


### PR DESCRIPTION
## Summary
- stop resetting the command flag when recap quick replies run without an active offer
- return an explicit command placeholder response so the pipeline skips model execution when no recap offer is active

## Testing
- node - <<'NODE' ... (simulated /да, /нет, /позже results)


------
https://chatgpt.com/codex/tasks/task_b_68dbb1a33450832991a20ecef7e56148