### PR TITLE
Adjust recap mute handling for /нет command

### DIFF
--- a/Input v16.0.7b-hotfix3.patched.txt
+++ b/Input v16.0.7b-hotfix3.patched.txt
@@ -73,7 +73,7 @@ const args   = tokens.slice(1);
           stop: true
         };
       }
-      LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn + 5; L.lastRecapTurn = L.turn;
+      LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn + 5;
       return reply("🚫 Recap postponed for 5 turns.");
     }
     if (cmd === "/позже"){


### PR DESCRIPTION
## Summary
- stop resetting `lastRecapTurn` when `/нет` is used so only the mute timer suppresses recap offers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbcabe98f083298ad0ba9b78062197