### PR TITLE
Ensure manual evergreen entries record history

### DIFF
--- a/Input v16.0.7b-hotfix3.patched.txt
+++ b/Input v16.0.7b-hotfix3.patched.txt
@@ -226,9 +226,8 @@ const args   = tokens.slice(1);
           let val = m[2].trim().replace(/\s+/g, " ").slice(0, 240);
           const allowed = ["facts","status","relations","obligations"];
           const target = allowed.indexOf(cat) === -1 ? "facts" : cat;
-          L.evergreen[target] = L.evergreen[target] || {};
           const key = `u_${Date.now().toString(36)}`;
-          L.evergreen[target][key] = val;
+          LC.evergreenManualSet(L, target, key, val);
           return reply(`Evergreen[${target}] += ${val.slice(0,80)}`);
         }
         return reply(LC.autoEvergreen.getSummary());

--- a/Library v16.0.7b-hotfix3.patched.txt
+++ b/Library v16.0.7b-hotfix3.patched.txt
@@ -1088,6 +1088,32 @@ L.debugMode = toBool(L.debugMode, false);
         LC.lcSys("Evergreen storage cleared.");
       }
     },
+    evergreenManualSet(L, category, key, value){
+      const state = L || this.lcInit();
+      if (!state || !state.evergreen || !category) return;
+      const allowed = ["relations","status","obligations","facts"];
+      const cat = String(category || "").toLowerCase();
+      if (allowed.indexOf(cat) === -1) return;
+      const val = String(value || "").trim();
+      if (!val) return;
+      const entryKey = key ? String(key) : `u_${Date.now().toString(36)}`;
+      if (!entryKey) return;
+      const box = (state.evergreen[cat] = state.evergreen[cat] || {});
+      const prev = Object.prototype.hasOwnProperty.call(box, entryKey) ? box[entryKey] : undefined;
+      box[entryKey] = val;
+      state.evergreen.history = Array.isArray(state.evergreen.history) ? state.evergreen.history : [];
+      const record = { turn: state.turn, category: cat, new: val, key: entryKey };
+      record.old = prev !== undefined ? prev : "";
+      state.evergreen.history.push(record);
+      const cap = Math.max(0, toNum(state.evergreenHistoryCap, 0));
+      if (cap > 0 && state.evergreen.history.length > cap) {
+        state.evergreen.history = state.evergreen.history.slice(-cap);
+      }
+      state.evergreen.lastUpdate = state.turn;
+      if (LC.autoEvergreen && typeof LC.autoEvergreen.limitCategories === "function") {
+        LC.autoEvergreen.limitCategories(state);
+      }
+    },
     capEvergreenHistory(max){
       const L = this.lcInit();
       const m = Math.max(0, toNum(max, 0));


### PR DESCRIPTION
## Summary
- add an evergreenManualSet helper to capture manual evergreen updates, trim history, and enforce category limits
- route the /evergreen set command through the helper so manual entries update history and lastUpdate metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dbd1ac3e808329a5888fdca8144ce4