### PR TITLE
Handle missing helpers in context modifier

### DIFF
--- a/Context v16.0.7b-hotfix3.patched.txt
+++ b/Context v16.0.7b-hotfix3.patched.txt
@@ -31,12 +31,18 @@ if (typeof LC === "undefined") return { text: String(text || "") };
   }
 
   // Canon
-  const canon = LC.autoEvergreen.getCanon();
+  const canon = LC.autoEvergreen?.getCanon?.();
   if (canon) priority.push(`⟦CANON⟧ ${canon}`);
 
   // Opening
-  const opening = LC.getOpeningLine();
-  if (opening) normal.push(opening);
+  const opening = LC.getOpeningLine?.();
+  if (opening) {
+    const openingStr = String(opening).trimStart();
+    const normalizedOpening = openingStr.startsWith("⟦OPENING⟧")
+      ? openingStr
+      : `⟦OPENING⟧ ${openingStr}`;
+    normal.push(normalizedOpening);
+  }
 
   // Characters
   const chars = LC.getActiveCharacters(10);


### PR DESCRIPTION
## Summary
- guard canon and opening helper lookups so missing LC helpers no longer throw
- normalize opening lines so they always begin with the ⟦OPENING⟧ tag before being queued

## Testing
- node smoke test with LC.autoEvergreen and LC.getOpeningLine undefined

------
https://chatgpt.com/codex/tasks/task_b_68dbd2b11c3c8329bcbedf368bcc1647