### PR TITLE
Adjust retry handling for turn increments and anti-echo

### DIFF
--- a/Output v16.0.7b-hotfix3.patched.txt
+++ b/Output v16.0.7b-hotfix3.patched.txt
@@ -62,17 +62,18 @@ const modifier = function (text) {
   }
 
   // Инкремент хода на реальном действии
-  if (LC.shouldIncrementTurn()) {
+  if (!isRetry && LC.shouldIncrementTurn()) {
     LC.incrementTurn();
-    L.lastOutput = clean;
-  } else {
-    L.lastOutput = clean;
   }
+  L.lastOutput = clean;
 
   // Anti-echo
   const actionType = L.lastActionType || "";
-  const filtered   = LC.applyAntiEcho(clean, L.prevOutput, actionType);
-  if (!isRetry) L.prevOutput = clean;
+  let filtered = clean;
+  if (!isRetry) {
+    filtered = LC.applyAntiEcho(clean, L.prevOutput, actionType);
+  }
+  L.prevOutput = filtered;
   out = filtered;
 
   // Черновики (Recap/Epoch)


### PR DESCRIPTION
## Summary
- skip turn increments when the modifier is processing a retry response
- bypass anti-echo trimming for retries and update the cache with the displayed prose

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dbd395703c83299f1a94895c079af1