### PR TITLE
Fix /ctx fallback sample preview for CRLF overlays

### DIFF
--- a/Input v16.0.7b-hotfix3.patched.txt
+++ b/Input v16.0.7b-hotfix3.patched.txt
@@ -472,9 +472,7 @@ const args   = tokens.slice(1);
     `SCENE: ${r.parts.SCENE||0}`,
     `META: ${r.parts.META||0}`
   ];
-  const sample = String(r.overlay).split("
-").slice(0,8).join("
-");
+  const sample = String(r.overlay).split(/\r?\n/).slice(0,8).join("\n");
 return reply("=== CONTEXT INSPECTOR ===\n" + lines.join(" | ") + "\n---\n" + sample);
       }
 


### PR DESCRIPTION
## Summary
- normalize the fallback /ctx overlay sample preview so Windows line endings are split correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dbe705d99083299c5cf4ea2c916fa4