### PR TITLE
chore: update Lincoln scripts to v16.0.8

### DIFF
--- a/Context v16.0.8.patched.txt
+++ b/Context v16.0.8.patched.txt
@@ -1,4 +1,4 @@
-﻿// === CONTEXT MODIFIER v16.0.7-compat6d ===
+﻿// === CONTEXT MODIFIER v16.0.8-compat6d ===
 const modifier = function (text) {
   
   const RETRY_KEEP_CONTEXT = (typeof LC !== 'undefined' && LC.lcGetFlag && (LC.lcGetFlag('RETRY_KEEP_CONTEXT', false) === true)); 

--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -1,4 +1,4 @@
-﻿// === INPUT MODIFIER v16.0.7-compat6d ===
+﻿// === INPUT MODIFIER v16.0.8-compat6d ===
 const modifier = function (text) {
   
 if (typeof LC === "undefined") return { text: String(text || "") };

--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -1,4 +1,4 @@
-﻿// === LIBRARY — Lincoln Heights Core v16.0.7-compat6d ===
+﻿// === LIBRARY — Lincoln Heights Core v16.0.8-compat6d ===
 
 (function () {
   // ---------- Utils ----------
@@ -19,8 +19,8 @@
   };
 
   const CONFIG = {
-  VERSION: "16.0.7-compat6d",
-  DATA_VERSION: "16.0.7b-hotfix3",
+  VERSION: "16.0.8-compat6d",
+  DATA_VERSION: "16.0.8",
   CHAR_WINDOW_HOT: 3,
   CHAR_WINDOW_ACTIVE: 10,
   CMD_PLACEHOLDER: "⟦SYS⟧ OK.",

--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -1,4 +1,4 @@
-﻿// === OUTPUT MODIFIER v16.0.7-compat6d ===
+﻿// === OUTPUT MODIFIER v16.0.8-compat6d ===
 function omBudget(start = Date.now(), ms = 280) { return () => { if (Date.now()-start > ms) throw new Error('OM_TIME_BUDGET'); }; } 
 const modifier = function (text) {
   if (typeof LC === "undefined") return { text: String(text || "") };


### PR DESCRIPTION
## Summary
- rename the context, input, library, and output script files to the v16.0.8 patch filenames
- bump the script headers and core config metadata to report version 16.0.8

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dbac37f0ac8329bf72dc3174526909