### PR TITLE
Adjust anti-echo baseline handling on retries

### DIFF
--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -72,8 +72,9 @@ const modifier = function (text) {
   let filtered = clean;
   if (!isRetry) {
     filtered = LC.applyAntiEcho(clean, L.prevOutput, actionType);
+    // Only update the anti-echo baseline when not retrying.
+    L.prevOutput = filtered;
   }
-  L.prevOutput = filtered;
   out = filtered;
 
   // Черновики (Recap/Epoch)


### PR DESCRIPTION
## Summary
- update the anti-echo logic to avoid overwriting the previous output baseline on retries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbfc30df9c8329899b8283cc7dd232