### PR TITLE
Guard context preview evergreen and opening helpers

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -110,10 +110,10 @@ const args   = tokens.slice(1);
         priority.push("⟦TASK⟧ NOW WRITE AN EPOCH: Compress multiple recaps into 5–7 sentences with major consequences and status changes.");
       }
 
-      const canon = LC.autoEvergreen.getCanon();
+      const canon = LC.autoEvergreen?.getCanon?.() || "";
       if (canon) priority.push(`⟦CANON⟧ ${canon}`);
 
-      const opening = LC.getOpeningLine();
+      const opening = LC.getOpeningLine?.() || "";
       if (opening) normal.push(opening);
 
       const chars = LC.getActiveCharacters(10);


### PR DESCRIPTION
## Summary
- guard the autoEvergreen canon lookup in the context preview
- guard the opening line lookup so the preview handles missing helpers gracefully

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dbfc61b4c483299b40356cf85dc58a