### PR TITLE
Reset command flags on stop responses

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -10,7 +10,18 @@ if (typeof LC === "undefined") return { text: String(text || "") };
   const userText = LC.stripYouWrappers(raw.trim());
 
   function reply(msg){ LC.lcSys(msg); return { text: LC.CONFIG.CMD_PLACEHOLDER }; }
-  function replyStop(msg){ LC.lcSys(msg); return { text: LC.CONFIG?.CMD_PLACEHOLDER ?? "⟦SYS⟧ OK.", stop: true, _sys: msg }; }
+  function clearCommandFlags(){
+    try {
+      LC.lcSetFlag("isCmd", false);
+      LC.lcSetFlag("isRetry", false);
+      LC.lcSetFlag("isContinue", false);
+    } catch (_) {}
+  }
+  function replyStop(msg){
+    LC.lcSys(msg);
+    clearCommandFlags();
+    return { text: LC.CONFIG?.CMD_PLACEHOLDER ?? "⟦SYS⟧ OK.", stop: true, _sys: msg };
+  }
 
   function extractCommand(s){
     let t = (s || "").trim();
@@ -38,6 +49,7 @@ const args   = tokens.slice(1);
     if (cmd === "/undo") {
       const n = Number(args[0] || 1);
       try { if (typeof LC !== 'undefined') LC.turnUndo(n); } catch(e) { try { LC.lcSys("⚠️ Undo failed."); } catch(_){} }
+      clearCommandFlags();
       return { text: "", stop: true };
     }
 
@@ -45,6 +57,7 @@ const args   = tokens.slice(1);
     if (cmd === "/turn" && (args[0] || "").toLowerCase() === "set") {
       const n = Number(args[1] || 0);
       try { if (typeof LC !== 'undefined') LC.turnSet(n); } catch(e) { try { LC.lcSys("⚠️ Turn set failed."); } catch(_){} }
+      clearCommandFlags();
       return { text: "", stop: true };
     }
 


### PR DESCRIPTION
## Summary
- clear command-related flags when stop responses are returned
- ensure /undo and /turn set stop paths also clear the flags before exiting

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dc16edfe9c8329bb8569266df511f8