### PR TITLE
Handle missing context length config fallback

### DIFF
--- a/Context v16.0.8.patched.txt
+++ b/Context v16.0.8.patched.txt
@@ -87,7 +87,7 @@ if (typeof LC === "undefined") return { text: String(text || "") };
   uniq.sort((a,b)=> weight(b) - weight(a));
 
   // 800-лимит
-  const MAX = LC.CONFIG.LIMITS.CONTEXT_LENGTH || 800;
+  const MAX = (LC.CONFIG && LC.CONFIG.LIMITS && LC.CONFIG.LIMITS.CONTEXT_LENGTH) || 800;
   let overlay = "";
   for (let i=0;i<uniq.length;i++){
     const line = uniq[i];


### PR DESCRIPTION
## Summary
- guard context length lookup to avoid accessing undefined configuration sections
- default the context overlay limit to 800 when configuration data is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc1f27e9788329be02f7928bb46e68