### PR TITLE
Adjust context preview config handling

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -112,13 +112,15 @@ const args   = tokens.slice(1);
       const opening = LC.getOpeningLine?.() || "";
       if (opening) normal.push(opening);
 
+      const HOT = LC.CONFIG?.CHAR_WINDOW_HOT ?? 3;
+      const ACTIVE = LC.CONFIG?.CHAR_WINDOW_ACTIVE ?? 10;
       const chars = LC.getActiveCharacters(10);
       if (chars.length) {
         const hot = []; const active = [];
         for (let i=0;i<chars.length;i++){
           const c = chars[i];
-          if (c.turnsAgo <= 3) hot.push(c.name);
-          else if (c.turnsAgo <= 10) active.push(c.name);
+          if (c.turnsAgo <= HOT) hot.push(c.name);
+          else if (c.turnsAgo <= ACTIVE) active.push(c.name);
         }
         if (hot.length)    priority.push(`⟦SCENE⟧ Focus on: ${hot.join(", ")}`);
         if (active.length) normal.push(`⟦SCENE⟧ Recently active: ${active.join(", ")}`);
@@ -148,7 +150,7 @@ const args   = tokens.slice(1);
       }
       uniq.sort((a,b)=> weight(b) - weight(a));
 
-      const MAX = LC.CONFIG.LIMITS.CONTEXT_LENGTH || 800;
+      const MAX = LC.CONFIG?.LIMITS?.CONTEXT_LENGTH ?? 800;
       let overlay = "";
       const parts = { GUIDE:0, INTENT:0, TASK:0, CANON:0, OPENING:0, SCENE:0, META:0 };
       for (let i=0;i<uniq.length;i++){


### PR DESCRIPTION
## Summary
- add configurable HOT and ACTIVE character window constants in context preview
- read context length limit with optional chaining and default fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc1f2bdc408329afb627c391369c8b