### PR TITLE
Update replyStop to surface stop notices

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -18,6 +18,13 @@ if (typeof LC === "undefined") return { text: String(text || "") };
     } catch (_) {}
   }
   function replyStop(msg){
+    let state;
+    try { state = LC.lcInit(); } catch (_) {}
+    if (state) {
+      const prev = (state.visibleNotice || "").trim();
+      state.visibleNotice = prev ? `${prev}\n${msg}` : msg;
+      if (state !== L) L.visibleNotice = state.visibleNotice;
+    }
     LC.lcSys(msg);
     clearCommandFlags();
     return { text: LC.CONFIG?.CMD_PLACEHOLDER ?? "⟦SYS⟧ OK.", stop: true, _sys: msg };


### PR DESCRIPTION
## Summary
- ensure `replyStop` refreshes the LC state before processing stop responses
- append stop messages to `visibleNotice` so they remain visible while retaining existing flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dc1f2c93bc83298d625a37275d3690