### PR TITLE
Make hot character window configurable

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -1188,7 +1188,8 @@ L.debugMode = toBool(L.debugMode, false);
         const decay = Math.pow(0.5, dt / half);
         score += (e.weight || 0.5) * decay;
       }
-      const hot = this.getActiveCharacters(10).filter(c => c.turnsAgo <= 3);
+      const hotWindow = (this.CONFIG?.CHAR_WINDOW_HOT ?? 3);
+      const hot = this.getActiveCharacters(10).filter(c => c.turnsAgo <= hotWindow);
       if (hot.length > 0) score += CONFIG.RECAP_V2.HOT_NPC_BONUS;
       return score;
     },


### PR DESCRIPTION
## Summary
- use the configured hot character window length when filtering active characters in computeRecapScore

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc1f2d99788329911637b5efb03b55