### PR TITLE
Add helper for visible notices and use it when scheduling auto epochs

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -152,6 +152,24 @@ L.debugMode = toBool(L.debugMode, false);
     lcError(m)  { this.lcSys("❌ " + m); const L=this.lcInit(); L.tm.errors=(L.tm.errors||0)+1; },
     lcDebug(m)  { const L=this.lcInit(); if (L.debugMode) this.lcSys("🔍 " + m); },
     lcConsumeMsgs(){ const L=this.lcInit(); const a=L.sysMsgs.slice(); L.sysMsgs=[]; return a; },
+    pushNotice(msg){
+      const text = toStr(msg).trim();
+      if (!text) return;
+      let L;
+      try {
+        L = this.lcInit();
+      } catch (err) {
+        try {
+          const st = getState();
+          L = st.lincoln = st.lincoln || {};
+        } catch (_) {
+          L = (typeof state !== "undefined" ? state.lincoln : null);
+        }
+      }
+      if (!L) return;
+      const current = toStr(L.visibleNotice || "").trim();
+      L.visibleNotice = [current, text].filter(Boolean).join("\n");
+    },
 
     // ---------- FLAGS ----------
     lcSetFlag(k,v){ const L=this.lcInit(); L.flags[toStr(k)] = v; },
@@ -1258,8 +1276,7 @@ L.debugMode = toBool(L.debugMode, false);
 
       if (recentRecaps >= CONFIG.RECAP_V2.AUTO_EPOCH_MIN_RECAPS || high) {
         this.lcSetFlag("doEpoch", true);
-        const noticeParts = [L.visibleNotice, "🗿 Epoch scheduled for next turn."];
-        L.visibleNotice = noticeParts.filter(Boolean).join("\n");
+        this.pushNotice("🗿 Epoch scheduled for next turn.");
         if (L.sysShow) this.lcSys("🗿 Epoch scheduled automatically.");
         return true;
       }


### PR DESCRIPTION
## Summary
- add an LC.pushNotice helper that appends notices safely
- reuse the helper when scheduling an automatic epoch to avoid duplicate assignment logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dc374f59848329a4775e9f449a1e81