### PR TITLE
Add module version guard across Lincoln scripts

### DIFF
--- a/Context v16.0.8.patched.txt
+++ b/Context v16.0.8.patched.txt
@@ -1,9 +1,13 @@
 ﻿// === CONTEXT MODIFIER v16.0.8-compat6d ===
+const __SCRIPT_SLOT__ = "Context";
+if (typeof LC !== "undefined") LC.DATA_VERSION = "16.0.8-compat6d";
+
 const modifier = function (text) {
   
   const RETRY_KEEP_CONTEXT = (typeof LC !== 'undefined' && LC.lcGetFlag && (LC.lcGetFlag('RETRY_KEEP_CONTEXT', false) === true)); 
 if (typeof LC === "undefined") return { text: String(text || "") };
-  const L = LC.lcInit();
+  LC.DATA_VERSION = "16.0.8-compat6d";
+  const L = LC.lcInit(__SCRIPT_SLOT__);
 
   const isRetry = LC.lcGetFlag("isRetry", false);
   if (isRetry && !RETRY_KEEP_CONTEXT) return { text: String(text || "") };

--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -1,8 +1,12 @@
 ﻿// === INPUT MODIFIER v16.0.8-compat6d ===
+const __SCRIPT_SLOT__ = "Input";
+if (typeof LC !== "undefined") LC.DATA_VERSION = "16.0.8-compat6d";
+
 const modifier = function (text) {
   
 if (typeof LC === "undefined") return { text: String(text || "") };
-  const L = LC.lcInit();
+  LC.DATA_VERSION = "16.0.8-compat6d";
+  const L = LC.lcInit(__SCRIPT_SLOT__);
 
   if (L.turn === 0 && !L.openingCaptured) LC.captureOpeningFromHistory();
 
@@ -19,7 +23,7 @@ if (typeof LC === "undefined") return { text: String(text || "") };
   }
   function replyStop(msg){
     let state;
-    try { state = LC.lcInit(); } catch (_) {}
+    try { state = LC.lcInit(__SCRIPT_SLOT__); } catch (_) {}
     if (state) {
       const prev = (state.visibleNotice || "").trim();
       state.visibleNotice = prev ? `${prev}\n${msg}` : msg;

--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -1,6 +1,8 @@
 ﻿// === LIBRARY — Lincoln Heights Core v16.0.8-compat6d ===
 
 (function () {
+  const __SCRIPT_SLOT__ = "Library";
+
   // ---------- Utils ----------
   const getState = () => (typeof state !== "undefined" ? state : {});
   const toNum  = (x, d=0)    => (typeof x === "number" && !isNaN(x)) ? x : (Number(x) || d);
@@ -20,7 +22,7 @@
 
   const CONFIG = {
   VERSION: "16.0.8-compat6d",
-  DATA_VERSION: "16.0.8",
+  DATA_VERSION: "16.0.8-compat6d",
   CHAR_WINDOW_HOT: 3,
   CHAR_WINDOW_ACTIVE: 10,
   CMD_PLACEHOLDER: "⟦SYS⟧ OK.",
@@ -60,10 +62,28 @@
 
   const LC = {
     CONFIG,
+    DATA_VERSION: "16.0.8-compat6d",
 
-    lcInit() {
+    lcInit(slot = __SCRIPT_SLOT__) {
       const st = getState();
       const L = (st.lincoln = st.lincoln || {});
+      const scriptSlot = toStr(slot || __SCRIPT_SLOT__ || "Library");
+      const seen = (L._modsSeen = L._modsSeen || {});
+      seen[scriptSlot] = LC.DATA_VERSION;
+      if (!L._versionCheckDone) {
+        const entries = Object.entries(seen).filter(([, v]) => v);
+        if (entries.length > 1) {
+          const baseVersion = entries[0][1];
+          const hasMismatch = entries.some(([, v]) => v !== baseVersion);
+          if (hasMismatch) {
+            const summary = entries.map(([name, v]) => `${name}=${v}`).join(", ");
+            const msg = `⚠️ Lincoln module data versions differ: ${summary}`;
+            const current = toStr(L.visibleNotice || "").trim();
+            L.visibleNotice = [current, msg].filter(Boolean).join("\n");
+            L._versionCheckDone = true;
+          }
+        }
+      }
       L.version = CONFIG.VERSION;
       // echo cache auto-flush on new session
       try { if ((L.turn|0) <= 0) { this._echoCache = {}; this._echoOrder = []; } } catch(_) {}

--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -1,8 +1,12 @@
 ﻿// === OUTPUT MODIFIER v16.0.8-compat6d ===
+const __SCRIPT_SLOT__ = "Output";
+if (typeof LC !== "undefined") LC.DATA_VERSION = "16.0.8-compat6d";
+
 function omBudget(start = Date.now(), ms = 280) { return () => { if (Date.now()-start > ms) throw new Error('OM_TIME_BUDGET'); }; } 
 const modifier = function (text) {
   if (typeof LC === "undefined") return { text: String(text || "") };
-  const L = LC.lcInit();
+  LC.DATA_VERSION = "16.0.8-compat6d";
+  const L = LC.lcInit(__SCRIPT_SLOT__);
   const notices = [];
   const _notice = (L.visibleNotice || "").trim();
   if (_notice) {


### PR DESCRIPTION
## Summary
- declare script slot identifiers in each Lincoln module and align LC.DATA_VERSION with v16.0.8-compat6d
- extend lcInit to accept the script slot, record module versions, and surface a visible notice when versions diverge

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dcd89f372083298470bf438850fa3c