### PR TITLE
Split post-analysis analyzer error handling

### DIFF
--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -103,9 +103,22 @@ const modifier = function (text) {
   if (!isRetry) {
     try {
       LC.updateCharacterActivity(out, false);
+    } catch (e) {
+      LC.lcWarn("Post-analyze updateCharacterActivity error: " + (e && e.message));
+    }
+    try {
       LC.analyzeTextForEvents(out, "output");
-      LC.autoEvergreen.analyze(out, actionType);
-    } catch (e) { LC.lcWarn("Post-analyze error: " + (e && e.message)); }
+    } catch (e) {
+      LC.lcWarn("Post-analyze analyzeTextForEvents error: " + (e && e.message));
+    }
+    const autoEvergreen = LC.autoEvergreen;
+    if (autoEvergreen?.analyze) {
+      try {
+        autoEvergreen.analyze(out, actionType);
+      } catch (e) {
+        LC.lcWarn("Post-analyze autoEvergreen error: " + (e && e.message));
+      }
+    }
   }
 
   // Авто-оффер recap и авто-epoch


### PR DESCRIPTION
## Summary
- split the post-analysis logic into dedicated try/catch blocks for each analyzer call
- guard the autoEvergreen analyzer invocation with optional chaining to tolerate its absence

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dcd8a09b988329b98c42a45886bed4