### PR TITLE
Add soft prune to anti-echo cache

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -532,7 +532,23 @@ L.debugMode = toBool(L.debugMode, false);
       this._echoCache[cacheKey] = res;
       this._echoOrder.push(cacheKey);
 
-      const max = CONFIG.LIMITS.ANTI_ECHO.CACHE_MAX;
+      const MAX = this.CONFIG?.LIMITS?.ANTI_ECHO?.CACHE_MAX ?? 256;
+      const softCap = Math.floor(MAX * 0.8);
+      if (this._echoOrder.length > softCap) {
+        const pruneCount = Math.max(1, Math.floor(this._echoOrder.length * 0.3));
+        const removedKeys = this._echoOrder.splice(0, pruneCount);
+        for (let i = 0; i < removedKeys.length; i++) {
+          const oldKey = removedKeys[i];
+          if (oldKey && this._echoCache[oldKey] !== undefined) {
+            delete this._echoCache[oldKey];
+          }
+        }
+        if (L.debugMode) {
+          this.lcDebug(`antiEcho: soft prune (-${removedKeys.length}, size=${this._echoOrder.length})`);
+        }
+      }
+
+      const max = MAX;
       if (this._echoOrder.length > max) {
         const toRemove = Math.floor(max / 2);
         for (let i=0;i<toRemove;i++){


### PR DESCRIPTION
## Summary
- compute the anti-echo cache capacity with a fallback value
- introduce a soft prune that drops roughly the oldest 30% of keys when usage exceeds 80%
- reuse the computed capacity for the existing hard-cap eviction logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dcd8a18fb4832983eda668fc984dfa