### PR TITLE
Handle partial overlay lines

### DIFF
--- a/Context v16.0.8.patched.txt
+++ b/Context v16.0.8.patched.txt
@@ -92,8 +92,17 @@ if (typeof LC === "undefined") return { text: String(text || "") };
   for (let i=0;i<uniq.length;i++){
     const line = uniq[i];
     const nl = overlay ? "\n" : "";
-    if ((overlay.length + line.length + nl.length) > MAX) continue;
-    overlay += nl + line;
+    const currentLength = overlay.length + nl.length;
+    const remaining = MAX - currentLength;
+    if (remaining <= 0) break;
+    if (line.length <= remaining) {
+      overlay += nl + line;
+      continue;
+    }
+    if (remaining >= 40) {
+      overlay += nl + line.slice(0, remaining);
+      break;
+    }
   }
 
   return { text: overlay };


### PR DESCRIPTION
## Summary
- update the overlay construction to track remaining space before appending
- allow partially appending a line when at least 40 characters remain
- stop processing once a partial append is made to avoid exceeding the limit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dcd8a55dc48329b9f9bdea7711c7b4