### PR TITLE
Use replyStop for informational commands

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -174,7 +174,7 @@ const args   = tokens.slice(1);
     switch ((cmd.split(" ")[0])) {
       case "/help":
       case "/h":
-        return reply([
+        return replyStop([
           `=== COMMANDS ${LC.CONFIG.VERSION} ===`,
           "/recap — create recap draft next output",
           "/epoch — create epoch draft",
@@ -201,12 +201,12 @@ const args   = tokens.slice(1);
       case "/ui":
         if (/\/ui\s+on/i.test(cmdRaw))  { L.sysShow = true;  return reply("✅ UI enabled."); }
         if (/\/ui\s+off/i.test(cmdRaw)) { L.sysShow = false; return reply("⚫ UI disabled."); }
-        return reply(`UI is ${L.sysShow ? "on" : "off"}.`);
+        return replyStop(`UI is ${L.sysShow ? "on" : "off"}.`);
 
       case "/debug":
         if (/\/debug\s+on/i.test(cmdRaw))  { L.debugMode = true;  return reply("🔍 Debug ON."); }
         if (/\/debug\s+off/i.test(cmdRaw)) { L.debugMode = false; return reply("🔍 Debug OFF."); }
-        return reply(`Debug is ${L.debugMode ? "on" : "off"}.`);
+        return replyStop(`Debug is ${L.debugMode ? "on" : "off"}.`);
 
       case "/recap":
         LC.lcSetFlag("doRecap", true);
@@ -218,13 +218,13 @@ const args   = tokens.slice(1);
 
       case "/continue":
         if (L.recapDraft || L.epochDraft) { LC.lcSetFlag("acceptDraft", true); return reply("✅ Draft will be saved now."); }
-        return reply("❌ No draft to save.");
+        return replyStop("❌ No draft to save.");
 
       case "/evergreen": {
         if (/\/evergreen\s+clear/i.test(cmdRaw)) { LC.autoEvergreen.clear(); return reply("🧹 Evergreen storage cleared."); }
         if (/\/evergreen\s+on/i.test(cmdRaw))    { LC.autoEvergreen.toggle(true);  return reply("🌿 Evergreen enabled."); }
         if (/\/evergreen\s+off/i.test(cmdRaw))   { LC.autoEvergreen.toggle(false); return reply("🌿 Evergreen disabled."); }
-        if (/\/evergreen\s+summary/i.test(cmdRaw)) { return reply(LC.autoEvergreen.getSummary()); }
+        if (/\/evergreen\s+summary/i.test(cmdRaw)) { return replyStop(LC.autoEvergreen.getSummary()); }
         const m = cmdRaw.match(/\/evergreen\s+set\s+([\w-]+):\s*(.+)$/i);
         if (m) {
           const cat = m[1].toLowerCase();
@@ -235,13 +235,13 @@ const args   = tokens.slice(1);
           LC.evergreenManualSet(L, target, key, val);
           return reply(`Evergreen[${target}] += ${val.slice(0,80)}`);
         }
-        return reply(LC.autoEvergreen.getSummary());
+        return replyStop(LC.autoEvergreen.getSummary());
       }
 
       case "/antiecho":
         if (/\/antiecho\s+stats/i.test(cmdRaw)) {
           const s = LC.antiEchoStats();
-          return reply([
+          return replyStop([
             "=== ANTI-ECHO STATS ===",
             `LRU size: ${s.lruSize}`,
             `Cache entries: ${s.cacheEntries}`,
@@ -261,11 +261,11 @@ const args   = tokens.slice(1);
           L.antiEchoMode = (cmdRaw.match(/mode\s+(soft|hard)/i)[1].toLowerCase() === "hard") ? "hard" : "soft";
           return reply(`🛡️ Anti-echo mode = ${L.antiEchoMode.toUpperCase()}`);
         }
-        (function(){
+        {
           const base = (L.antiEchoSensitivity || 85) / 100;
           const multSoft = LC.CONFIG.LIMITS.ANTI_ECHO.CONTINUE_THRESHOLD_MULT.SOFT;
           const multHard = LC.CONFIG.LIMITS.ANTI_ECHO.CONTINUE_THRESHOLD_MULT.HARD;
-          LC.lcSys([
+          return replyStop([
             "=== ANTI-ECHO SETTINGS ===",
             `Status: ${L.antiEchoEnabled ? "Enabled" : "Disabled"}`,
             `Sensitivity: ${L.antiEchoSensitivity || 85}%`,
@@ -273,15 +273,14 @@ const args   = tokens.slice(1);
             `Continue thr (soft/hard): ${(Math.min(0.99, base*multSoft)).toFixed(2)} / ${(Math.min(0.99, base*multHard)).toFixed(2)}`,
             `Echo hits: ${L.tm.echoHits || 0}`
           ].join("\n"));
-        })();
-        return { text: LC.CONFIG.CMD_PLACEHOLDER };
+        }
 
       case "/events": {
         const m = cmdRaw.match(/\/events(?:\s+(\d+))?/i);
         const n = m && m[1] ? parseInt(m[1],10) : 10;
         const diag = LC.getEventsDiagnostics(n);
         const lines = diag.rows.map(r => `${r.type.padEnd(10)} | turn ${String(r.turn).padStart(3)} | ${String(r.ago).padStart(2)} ago | w=${r.w} decay=${r.decay} → +${r.contrib}`);
-        return reply([
+        return replyStop([
           `=== EVENTS (last ${diag.rows.length}) — contribution total: +${diag.total} ===`,
           ...lines
         ].join("\n"));
@@ -291,13 +290,13 @@ const args   = tokens.slice(1);
         if (/\/alias\s+list/i.test(cmdRaw)) {
           const map = L.aliases || {};
           const keys = Object.keys(map);
-          if (!keys.length) return reply("No custom aliases.");
+          if (!keys.length) return replyStop("No custom aliases.");
           const out = keys.map(k => `${k}: ${map[k].join(", ")}`);
-          return reply("=== ALIASES ===\n" + out.join("\n"));
+          return replyStop("=== ALIASES ===\n" + out.join("\n"));
         }
         if (/\/alias\s+add\s+/i.test(cmdRaw)) {
           const m = cmdRaw.match(/\/alias\s+add\s+([^=]+)=(.+)$/i);
-          if (!m) return reply("Usage: /alias add <Name>=a,b,c");
+          if (!m) return replyStop("Usage: /alias add <Name>=a,b,c");
           const name = m[1].trim();
           const list = m[2].split(",").map(s=>s.trim()).filter(Boolean);
           L.aliases[name] = list;
@@ -305,12 +304,12 @@ const args   = tokens.slice(1);
         }
         if (/\/alias\s+del\s+/i.test(cmdRaw)) {
           const m = cmdRaw.match(/\/alias\s+del\s+(.+)$/i);
-          if (!m) return reply("Usage: /alias del <Name>");
+          if (!m) return replyStop("Usage: /alias del <Name>");
           const name = m[1].trim();
           if (name in L.aliases) { delete L.aliases[name]; return reply(`Alias deleted: ${name}`); }
-          return reply(`No alias for: ${name}`);
+          return replyStop(`No alias for: ${name}`);
         }
-        return reply("Usage: /alias add <Name>=a,b,c | /alias del <Name> | /alias list");
+        return replyStop("Usage: /alias add <Name>=a,b,c | /alias del <Name> | /alias list");
       }
 
       case "/evhist": {
@@ -322,30 +321,30 @@ const args   = tokens.slice(1);
         if (/\/evhist\s+last\s+(\d+)/i.test(cmdRaw)) {
           const n = Math.max(1, parseInt(cmdRaw.match(/last\s+(\d+)/i)[1],10));
           const arr = (L.evergreen && Array.isArray(L.evergreen.history)) ? L.evergreen.history.slice(-n) : [];
-          if (!arr.length) return reply("Evergreen history is empty.");
+          if (!arr.length) return replyStop("Evergreen history is empty.");
           const show = arr.map(h => {
             const oldS = String(h.old||"").slice(0,40);
             const newS = String(h.new||"").slice(0,40);
             return `t${h.turn} [${h.category}] ${oldS} ⇒ ${newS}`;
           });
-          return reply("=== EV HISTORY ===\n" + show.join("\n"));
+          return replyStop("=== EV HISTORY ===\n" + show.join("\n"));
         }
         if (/\/evhist\s+clear/i.test(cmdRaw)) {
           if (L.evergreen) L.evergreen.history = [];
           return reply("Evergreen history cleared.");
         }
-        return reply("Usage: /evhist cap <N> | /evhist last <N> | /evhist clear");
+        return replyStop("Usage: /evhist cap <N> | /evhist last <N> | /evhist clear");
       }
 
       case "/characters": {
         const chars = LC.getActiveCharacters(10);
-        if (chars.length) return reply("=== ACTIVE CHARACTERS ===\n" +
+        if (chars.length) return replyStop("=== ACTIVE CHARACTERS ===\n" +
           chars.map(c => `${c.name}: ${c.mentions} mentions, ${c.turnsAgo} turns ago`).join("\n"));
-        return reply("No active characters tracked yet.");
+        return replyStop("No active characters tracked yet.");
       }
 
       case "/opening":
-        return reply(LC.getOpeningLine() || "No opening captured yet.");
+        return replyStop(LC.getOpeningLine() || "No opening captured yet.");
 
       case "/retry":
         
@@ -359,7 +358,7 @@ const args   = tokens.slice(1);
     return reply("🔁 Retry: keep context = OFF.");
   }
   const keep = LC.lcGetFlag("RETRY_KEEP_CONTEXT", false);
-  return reply([
+  return replyStop([
     "=== RETRY ===",
     `Consecutive: ${L.consecutiveRetries || 0}`,
     `Total: ${L.tm?.retries || 0}`,
@@ -372,7 +371,7 @@ const args   = tokens.slice(1);
 
       case "/stats": {
         const s = (L.tm.lastRecapScore == null) ? "n/a" : Number(L.tm.lastRecapScore).toFixed(2);
-        return reply([
+        return replyStop([
           `=== STATISTICS ${LC.CONFIG.VERSION} ===`,
           `Turn: ${L.turn}`,
           `Since recap: ${L.turn - (L.lastRecapTurn || 0)}`,
@@ -396,25 +395,25 @@ const args   = tokens.slice(1);
           if (req !== v) return reply(`⏱️ Recap cadence: requested ${req} → applied ${v} (range ${LC.CONFIG.LIMITS.CADENCE.MIN}-${LC.CONFIG.LIMITS.CADENCE.MAX}).`);
           return reply(`⏱️ Recap cadence → ${v} turns.`);
         }
-        return reply(`Current cadence: ${L.cadence} turns.`);
+        return replyStop(`Current cadence: ${L.cadence} turns.`);
       }
 
       case "/story": {
         if (/^\/story\s+add\s+/i.test(cmdRaw)) {
           const m = cmdRaw.match(/^\/story\s+add\s+([\s\S]+)$/i);
           const entry = m ? m[1].trim() : "";
-          if (!entry || entry.length < 10) return reply("Usage: /story add <текст карточки (≥10 символов)>");
+          if (!entry || entry.length < 10) return replyStop("Usage: /story add <текст карточки (≥10 символов)>");
           const id = LC.createStoryCard(entry, [Math.max(0, L.turn - L.cadence), L.turn], "note");
           return reply(`📝 Card saved — ID: ${id}`);
         }
         if (/^\/story\s+del\s+/i.test(cmdRaw)) {
           const m = cmdRaw.match(/^\/story\s+del\s+(\S+)/i);
-          if (!m) return reply("Usage: /story del <id>");
+          if (!m) return replyStop("Usage: /story del <id>");
           const id = m[1].trim();
           const ok = LC.removeStoryCardById(id);
           return reply(ok ? `🗑️ Card ${id} removed.` : `🔎 Card ${id} not found (removed from registry if present).`);
         }
-        return reply("Usage: /story add <text> | /story del <id>");
+        return replyStop("Usage: /story add <text> | /story del <id>");
       }
 
       case "/cards": {
@@ -426,8 +425,8 @@ const args   = tokens.slice(1);
           if (id) extSet[id] = 1;
         }
         const ids = L.worldInfoIds.slice(-15);
-        if (!ids.length) return reply("No managed cards.");
-        return reply("=== CARDS (managed) ===\n" + 
+        if (!ids.length) return replyStop("No managed cards.");
+        return replyStop("=== CARDS (managed) ===\n" +
           ids.map((id,i)=>{
             const pin = (L.pinnedWorldInfoIds.indexOf(id)!==-1) ? " [PIN]" : "";
             const mk  = extSet[id] ? " [EXT]" : "";
@@ -437,7 +436,7 @@ const args   = tokens.slice(1);
 
       case "/pin": {
         const m = cmdRaw.match(/\/pin\s+(\S+)/i);
-        if (!m) return reply("Usage: /pin <id>");
+        if (!m) return replyStop("Usage: /pin <id>");
         const id = m[1];
         if (L.pinnedWorldInfoIds.indexOf(id) === -1) L.pinnedWorldInfoIds.push(id);
         return reply(`📌 Pseudo-pin set for ${id}.`);
@@ -445,7 +444,7 @@ const args   = tokens.slice(1);
 
       case "/unpin": {
         const m = cmdRaw.match(/\/unpin\s+(\S+)/i);
-        if (!m) return reply("Usage: /unpin <id>");
+        if (!m) return replyStop("Usage: /unpin <id>");
         const id = m[1];
         const p = L.pinnedWorldInfoIds.indexOf(id);
         if (p !== -1) L.pinnedWorldInfoIds.splice(p,1);
@@ -454,7 +453,7 @@ const args   = tokens.slice(1);
 
       case "/del": {
         const m = cmdRaw.match(/\/del\s+(\S+)/i);
-        if (!m) return reply("Usage: /del <id>");
+        if (!m) return replyStop("Usage: /del <id>");
         const id = m[1];
         const p = L.pinnedWorldInfoIds.indexOf(id);
         if (p !== -1) L.pinnedWorldInfoIds.splice(p,1);
@@ -463,45 +462,44 @@ const args   = tokens.slice(1);
       }
 
       case "/ctx": {
-  try { if (typeof LC !== "undefined" && LC.ctxPreview) { return reply(LC.ctxPreview()); } } catch(_){/* fallback */}
-  
-  // Fallback to local preview builder
-  const r = (typeof buildContextPreview === "function") ? buildContextPreview() : { overlay:"", max:800, parts:{} };
-  const lines = [
-    `LEN: ${r.overlay.length}/${r.max}`,
-    `GUIDE: ${r.parts.GUIDE||0}`,
-    `INTENT: ${r.parts.INTENT||0}`,
-    `TASK: ${r.parts.TASK||0}`,
-    `CANON: ${r.parts.CANON||0}`,
-    `OPENING: ${r.parts.OPENING||0}`,
-    `SCENE: ${r.parts.SCENE||0}`,
-    `META: ${r.parts.META||0}`
-  ];
-  const sample = String(r.overlay).split(/\r?\n/).slice(0,8).join("\n");
-return reply("=== CONTEXT INSPECTOR ===\n" + lines.join(" | ") + "\n---\n" + sample);
+        try { if (typeof LC !== "undefined" && LC.ctxPreview) { return replyStop(LC.ctxPreview()); } } catch(_){/* fallback */}
+
+        // Fallback to local preview builder
+        const r = (typeof buildContextPreview === "function") ? buildContextPreview() : { overlay:"", max:800, parts:{} };
+        const lines = [
+          `LEN: ${r.overlay.length}/${r.max}`,
+          `GUIDE: ${r.parts.GUIDE||0}`,
+          `INTENT: ${r.parts.INTENT||0}`,
+          `TASK: ${r.parts.TASK||0}`,
+          `CANON: ${r.parts.CANON||0}`,
+          `OPENING: ${r.parts.OPENING||0}`,
+          `SCENE: ${r.parts.SCENE||0}`,
+          `META: ${r.parts.META||0}`
+        ];
+        const sample = String(r.overlay).split(/\r?\n/).slice(0,8).join("\n");
+        return replyStop("=== CONTEXT INSPECTOR ===\n" + lines.join(" | ") + "\n---\n" + sample);
       }
 
       case "/selftest": {
-{
-  const cfg = LC.CONFIG || {};
-  const anti = [
-    L.antiEchoEnabled ? "ON" : "OFF",
-    (L.antiEchoMode || "soft"),
-    `@${L.antiEchoSensitivity ?? 85}%`
-  ].join(" ");
-  return reply([
-    "=== SELFTEST ===",
-    `Version: ${cfg.VERSION || "n/a"}`,
-    `Data: ${cfg.DATA_VERSION || "n/a"}`,
-    `Cadence: ${L.cadence} (muteUntil=${L.recapMuteUntil ?? "-"}, sinceRecap=${(L.turn - (L.lastRecapTurn || 0)) || 0})`,
-    `Anti-echo: ${anti}`,
-    `Flags: isCmd=${LC.lcGetFlag("isCmd",false)}, isRetry=${LC.lcGetFlag("isRetry",false)}, isContinue=${LC.lcGetFlag("isContinue",false)}, RETRY_KEEP_CONTEXT=${LC.lcGetFlag("RETRY_KEEP_CONTEXT",false)}`
-  ].join("\n"));
-}
+        const cfg = LC.CONFIG || {};
+        const anti = [
+          L.antiEchoEnabled ? "ON" : "OFF",
+          (L.antiEchoMode || "soft"),
+          `@${L.antiEchoSensitivity ?? 85}%`
+        ].join(" ");
+        return replyStop([
+          "=== SELFTEST ===",
+          `Version: ${cfg.VERSION || "n/a"}`,
+          `Data: ${cfg.DATA_VERSION || "n/a"}`,
+          `Cadence: ${L.cadence} (muteUntil=${L.recapMuteUntil ?? "-"}, sinceRecap=${(L.turn - (L.lastRecapTurn || 0)) || 0})`,
+          `Anti-echo: ${anti}`,
+          `Flags: isCmd=${LC.lcGetFlag("isCmd",false)}, isRetry=${LC.lcGetFlag("isRetry",false)}, isContinue=${LC.lcGetFlag("isContinue",false)}, RETRY_KEEP_CONTEXT=${LC.lcGetFlag("RETRY_KEEP_CONTEXT",false)}`
+        ].join("\n"));
+      }
 
 
       default:
-        return reply("Unknown command. Use /help.");
+        return replyStop("Unknown command. Use /help.");
     }
   }
 


### PR DESCRIPTION
## Summary
- switch pure informational command responses like /help, /stats, /cards, and other listings to use `replyStop` so they emit the same LC.lcSys messages without consuming the turn
- update validation fallbacks and context inspection/self-test outputs to route through `replyStop`, keeping command flags cleared via `clearCommandFlags`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dcd8a5df088329802f41262075fe4c