### PR TITLE
Enhance /selftest diagnostics output

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -491,14 +491,24 @@ const args   = tokens.slice(1);
           (L.antiEchoMode || "soft"),
           `@${L.antiEchoSensitivity ?? 85}%`
         ].join(" ");
-        return replyStop([
+        const out = [
           "=== SELFTEST ===",
           `Version: ${cfg.VERSION || "n/a"}`,
           `Data: ${cfg.DATA_VERSION || "n/a"}`,
           `Cadence: ${L.cadence} (muteUntil=${L.recapMuteUntil ?? "-"}, sinceRecap=${(L.turn - (L.lastRecapTurn || 0)) || 0})`,
           `Anti-echo: ${anti}`,
           `Flags: isCmd=${LC.lcGetFlag("isCmd",false)}, isRetry=${LC.lcGetFlag("isRetry",false)}, isContinue=${LC.lcGetFlag("isContinue",false)}, RETRY_KEEP_CONTEXT=${LC.lcGetFlag("RETRY_KEEP_CONTEXT",false)}`
-        ].join("\n"));
+        ];
+        const mods = (L && L._modsSeen) || {};
+        const modList = Object.entries(mods).map(([k,v]) => `${k}:${v}`).join(", ");
+        out.push(`versions=[${modList}]`);
+        clearCommandFlags();
+        const flagsReset = !LC.lcGetFlag("isCmd", false) && !LC.lcGetFlag("isRetry", false) && !LC.lcGetFlag("isContinue", false);
+        out.push(`flagsReset=${flagsReset}`);
+        out.push(`echoCache=${LC._echoOrder?.length ?? 0}`);
+        const ever = (L && L.evergreen) || {};
+        out.push(`evHist=${ever.history?.length ?? 0}`);
+        return replyStop(out.join("\n"));
       }
 
 


### PR DESCRIPTION
## Summary
- update the `/selftest` command to accumulate diagnostics before replying
- include module registry versions, flag reset validation, and cache metrics in the output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dce288dca48329838ccb9b3d3ad5ce