### PR TITLE
Add non-breaking Flags API helpers

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -1448,6 +1448,14 @@ L.debugMode = toBool(L.debugMode, false);
     }
   };
 
+  // ===== Flags API (non-breaking) =====
+  LC.Flags = LC.Flags || {
+    setCmd(){ LC.lcSetFlag?.("isCmd", true); LC.lcSetFlag?.("isRetry", false); LC.lcSetFlag?.("isContinue", false); },
+    clearCmd(){ LC.lcSetFlag?.("isCmd", false); LC.lcSetFlag?.("isRetry", false); LC.lcSetFlag?.("isContinue", false); },
+    queueRecap(){ LC.lcSetFlag?.("doRecap", true); },
+    queueEpoch(){ LC.lcSetFlag?.("doEpoch", true); },
+  };
+
   if (typeof globalThis !== "undefined") globalThis.LC = LC;
   if (typeof window !== "undefined") window.LC = LC;
 })();


### PR DESCRIPTION
## Summary
- add a non-breaking LC.Flags helper object so callers can toggle command and recap flags

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dd1a34eaac832993bd990fb82adfcc