### PR TITLE
Use cached normalization in evergreen analysis

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -862,7 +862,7 @@ L.debugMode = toBool(L.debugMode, false);
         const L = LC.lcInit();
         if (!this.patterns) this.patterns = this._buildPatterns();
         if (!L.evergreen || !L.evergreen.enabled || actionType === "retry" || !text) return;
-        const T = String(text);
+        const T = LC._normUCached?.(text) ?? LC._normU(text);
 
         const formatRelation = (subject, action, object, raw, patternType, options={})=>{
           const subj = String(subject || "").trim();


### PR DESCRIPTION
## Summary
- update `LC.autoEvergreen.analyze` to use the cached normalizer when available while falling back to `_normU`
- verified that the `USE_NORM_CACHE` feature flag remains disabled by default

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dd3b74216c8329967333942f58b12c