### PR TITLE
Simplify version mismatch notice handling

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -97,8 +97,7 @@
           if (hasMismatch) {
             const summary = entries.map(([name, v]) => `${name}=${v}`).join(", ");
             const msg = `⚠️ Lincoln module data versions differ: ${summary}`;
-            const current = toStr(L.visibleNotice || "").trim();
-            L.visibleNotice = [current, msg].filter(Boolean).join("\n");
+            LC.pushNotice?.(msg);
             L._versionCheckDone = true;
           }
         }


### PR DESCRIPTION
## Summary
- use LC.pushNotice when reporting module version mismatches
- remove redundant visibleNotice accumulation logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dd3fdbc0c083298f10513c6b8ce47a