### PR TITLE
Map selftest flagsReset output to status string

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -517,7 +517,8 @@ const args   = tokens.slice(1);
           } catch (_) {}
           return !LC.lcGetFlag("isCmd", false) && !LC.lcGetFlag("isRetry", false) && !LC.lcGetFlag("isContinue", false);
         })();
-        out.push(`flagsReset=${flagsReset}`);
+        const flagsResetStatus = flagsReset ? "ok" : "warn";
+        out.push(`flagsReset=${flagsResetStatus}`);
         out.push(`echoCache=${LC._echoOrder?.length ?? 0}`);
         const ever = (L && L.evergreen) || {};
         out.push(`evHist=${ever.history?.length ?? 0}`);


### PR DESCRIPTION
## Summary
- report the /selftest flagsReset status as "ok" or "warn" instead of a boolean value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dd426e4b2c832994bb390660639374