### PR TITLE
Add fallback for selftest module version list

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -506,7 +506,8 @@ const args   = tokens.slice(1);
         ];
         const mods = (L && L._modsSeen) || {};
         const modList = Object.entries(mods).map(([k,v]) => `${k}:${v}`).join(", ");
-        out.push(`versions=[${modList}]`);
+        const modSummary = modList || "n/a";
+        out.push(`versions=[${modSummary}]`);
         const flagsReset = (() => {
           try {
             if (LC.Flags?.clearCmd) {


### PR DESCRIPTION
## Summary
- ensure the /selftest handler reports "n/a" when no module versions are recorded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dd426ba6748329927f3e856cd61162