### PR TITLE
Add LC.Turns facade

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -1482,6 +1482,12 @@ L.debugMode = toBool(L.debugMode, false);
     queueEpoch(){ LC.lcSetFlag?.("doEpoch", true); },
   };
 
+  LC.Turns = LC.Turns || {
+    incIfNeeded(){ if (!LC.lcGetFlag?.("isCmd") && !LC.lcGetFlag?.("isRetry")) { const L=LC.lcInit(); L.turn=(L.turn|0)+1; } },
+    set(n){ LC.turnSet?.(n); },
+    undo(n){ LC.turnUndo?.(n); },
+  };
+
   if (typeof globalThis !== "undefined") globalThis.LC = LC;
   if (typeof window !== "undefined") window.LC = LC;
 })();


### PR DESCRIPTION
## Summary
- introduce an LC.Turns facade alongside the Flags API
- provide helpers to increment the turn only when needed and wrap existing turn setters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dd4a2f458483298fd945d81ebdc8f1