### PR TITLE
Refine bypass reply helpers

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -21,15 +21,19 @@ if (typeof LC === "undefined") return { text: String(text || "") };
   const raw = String(text || "");
   const userText = LC.stripYouWrappers(raw.trim());
 
-  function reply(msg){ LC.lcSys(msg); return { text: LC.CONFIG.CMD_PLACEHOLDER }; }
+  function reply(msg){
+    LC.lcSys(msg);
+    return { text: LC.CONFIG?.CMD_PLACEHOLDER ?? "⟦SYS⟧ OK." };
+  }
   function clearCommandFlags(){
     try {
       LC.Flags?.clearCmd?.();
     } catch (_) {}
   }
   function replyStop(msg){
-    let state;
-    try { state = LC.lcInit(__SCRIPT_SLOT__); } catch (_) {}
+    const state = (L && typeof L === "object") ? L : (() => {
+      try { return LC.lcInit(__SCRIPT_SLOT__); } catch (_) { return null; }
+    })();
     if (state) {
       LC.pushNotice?.(msg);
     }


### PR DESCRIPTION
## Summary
- ensure the standard reply helper falls back to a default placeholder when the config value is missing
- reuse the current command state when queueing notices for bypass responses, only reinitialising as a fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dd459ec34083298954fecf5d5374d7