### PR TITLE
Refactor context overlay composition

### DIFF
--- a/Context v16.0.8.patched.txt
+++ b/Context v16.0.8.patched.txt
@@ -22,100 +22,10 @@ if (typeof LC === "undefined") return { text: String(text || "") };
 
   const isCmd = LC.lcGetFlag("isCmd", false);
 
-  const priority = [];
-  const normal = [];
-
-  // Style guides
-  priority.push("⟦GUIDE⟧ Lincoln Heights school drama. Third person past tense.");
-  priority.push("⟦GUIDE⟧ 2–4 short paragraphs. Show emotions via actions and subtext.");
-  priority.push("⟦GUIDE⟧ Keep it plausible and consistent. PG-16.");
-  normal.push("⟦GUIDE⟧ Do NOT repeat last 2–3 sentences from previous output.");
-
-  // Intent
-  if (L.lastIntent && L.lastIntent.length > 2) priority.push(`⟦INTENT⟧ ${L.lastIntent}`);
-
-  // Tasks
-  if (!isCmd && LC.lcGetFlag("doRecap", false)) {
-    priority.push("⟦TASK⟧ NOW WRITE A RECAP: Summarize the last 10–15 turns in 5–7 clear sentences, focusing on key events/relationships and current situation.");
-  }
-  if (!isCmd && LC.lcGetFlag("doEpoch", false)) {
-    priority.push("⟦TASK⟧ NOW WRITE AN EPOCH: Compress multiple recaps into 5–7 sentences with major consequences and status changes.");
-  }
-
-  // Canon
-  const canon = LC.autoEvergreen?.getCanon?.();
-  if (canon) priority.push(`⟦CANON⟧ ${canon}`);
-
-  // Opening
-  const opening = LC.getOpeningLine?.();
-  if (opening) {
-    const openingStr = String(opening).trimStart();
-    const normalizedOpening = openingStr.startsWith("⟦OPENING⟧")
-      ? openingStr
-      : `⟦OPENING⟧ ${openingStr}`;
-    normal.push(normalizedOpening);
-  }
-
-  // Characters
-  const chars = LC.getActiveCharacters(10);
-  if (chars.length) {
-    const hot = []; const active = [];
-    for (let i=0;i<chars.length;i++){
-      const c = chars[i];
-      if (c.turnsAgo <= (LC.CONFIG.CHAR_WINDOW_HOT || 3)) hot.push(c.name);
-      else if (c.turnsAgo <= (LC.CONFIG.CHAR_WINDOW_ACTIVE || 10)) active.push(c.name);
-    }
-    if (hot.length)    priority.push(`⟦SCENE⟧ Focus on: ${hot.join(", ")}`);
-    if (active.length) normal.push(`⟦SCENE⟧ Recently active: ${active.join(", ")}`);
-  }
-
-  // META
-  if (L.turn > 0) {
-    const sinceRecap = L.turn - (L.lastRecapTurn || 0);
-    const sinceEpoch = L.turn - (L.lastEpochTurn || 0);
-    const retryInfo = L.consecutiveRetries > 0 ? ` (${L.consecutiveRetries} retries)` : "";
-    normal.push(`⟦META⟧ Turn ${L.turn}${retryInfo}, ${sinceRecap} since recap, ${sinceEpoch} since epoch.`);
-  }
-
-  // Dedup + sort
-  const all = priority.concat(normal);
-  const seen = {};
-  const uniq = [];
-  for (let i=0;i<all.length;i++){
-    const r = all[i]; const k = r.toLowerCase();
-    if (!seen[k]){ seen[k] = 1; uniq.push(r); }
-  }
-  function weight(line){
-    if (line.indexOf("⟦INTENT⟧") === 0) return 1000;
-    if (line.indexOf("⟦TASK⟧") === 0)   return 900;
-    if (line.indexOf("⟦CANON⟧") === 0)  return 800;
-    if (line.indexOf("⟦OPENING⟧") === 0)return 700;
-    if (line.indexOf("⟦SCENE⟧") === 0 && line.indexOf("Focus") !== -1) return 600;
-    if (line.indexOf("⟦SCENE⟧") === 0)  return 500;
-    if (line.indexOf("⟦GUIDE⟧") === 0)  return 400;
-    if (line.indexOf("⟦META⟧") === 0)   return 100;
-    return 0;
-  }
-  uniq.sort((a,b)=> weight(b) - weight(a));
-
-  // 800-лимит
-  const MAX = (LC.CONFIG && LC.CONFIG.LIMITS && LC.CONFIG.LIMITS.CONTEXT_LENGTH) || 800;
-  let overlay = "";
-  for (let i=0;i<uniq.length;i++){
-    const line = uniq[i];
-    const nl = overlay ? "\n" : "";
-    const currentLength = overlay.length + nl.length;
-    const remaining = MAX - currentLength;
-    if (remaining <= 0) break;
-    if (line.length <= remaining) {
-      overlay += nl + line;
-      continue;
-    }
-    if (remaining >= 40) {
-      overlay += nl + line.slice(0, remaining);
-      break;
-    }
-  }
+  const limit = (LC.CONFIG && LC.CONFIG.LIMITS && LC.CONFIG.LIMITS.CONTEXT_LENGTH) || 800;
+  const built = LC.composeContextOverlay?.({ limit, allowPartial: true });
+  const overlayRaw = (built && typeof built.text === "string") ? built.text : String(built?.text || "");
+  const overlay = overlayRaw.length > limit ? overlayRaw.slice(0, limit) : overlayRaw;
 
   return { text: overlay };
 };

--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -103,84 +103,6 @@ const args   = tokens.slice(1);
       return reply("🕑 Recap later (3 turns).");
     }
 
-// helpers for /ctx
-    function buildContextPreview(){
-      const priority = [];
-      const normal = [];
-
-      // Style guides
-      priority.push("⟦GUIDE⟧ Lincoln Heights school drama. Third person past tense.");
-      priority.push("⟦GUIDE⟧ 2–4 short paragraphs. Show emotions via actions and subtext.");
-      priority.push("⟦GUIDE⟧ Keep it plausible and consistent. PG-16.");
-      normal.push("⟦GUIDE⟧ Do NOT repeat last 2–3 sentences from previous output.");
-
-      if (L.lastIntent && L.lastIntent.length > 2) priority.push(`⟦INTENT⟧ ${L.lastIntent}`);
-
-      if (!LC.lcGetFlag("isCmd", false) && LC.lcGetFlag("doRecap", false)) {
-        priority.push("⟦TASK⟧ NOW WRITE A RECAP: Summarize the last 10–15 turns in 5–7 clear sentences, focusing on key events/relationships and current situation.");
-      }
-      if (!LC.lcGetFlag("isCmd", false) && LC.lcGetFlag("doEpoch", false)) {
-        priority.push("⟦TASK⟧ NOW WRITE AN EPOCH: Compress multiple recaps into 5–7 sentences with major consequences and status changes.");
-      }
-
-      const canon = LC.autoEvergreen?.getCanon?.() || "";
-      if (canon) priority.push(`⟦CANON⟧ ${canon}`);
-
-      const opening = LC.getOpeningLine?.() || "";
-      if (opening) normal.push(opening);
-
-      const HOT = LC.CONFIG?.CHAR_WINDOW_HOT ?? 3;
-      const ACTIVE = LC.CONFIG?.CHAR_WINDOW_ACTIVE ?? 10;
-      const chars = LC.getActiveCharacters(10);
-      if (chars.length) {
-        const hot = []; const active = [];
-        for (let i=0;i<chars.length;i++){
-          const c = chars[i];
-          if (c.turnsAgo <= HOT) hot.push(c.name);
-          else if (c.turnsAgo <= ACTIVE) active.push(c.name);
-        }
-        if (hot.length)    priority.push(`⟦SCENE⟧ Focus on: ${hot.join(", ")}`);
-        if (active.length) normal.push(`⟦SCENE⟧ Recently active: ${active.join(", ")}`);
-      }
-
-      if (L.turn > 0) {
-        const sinceRecap = L.turn - (L.lastRecapTurn || 0);
-        const sinceEpoch = L.turn - (L.lastEpochTurn || 0);
-        const retryInfo = L.consecutiveRetries > 0 ? ` (${L.consecutiveRetries} retries)` : "";
-        normal.push(`⟦META⟧ Turn ${L.turn}${retryInfo}, ${sinceRecap} since recap, ${sinceEpoch} since epoch.`);
-      }
-
-      const all = priority.concat(normal);
-      const seen = {}; const uniq = [];
-      for (let i=0;i<all.length;i++){ const r=all[i]; const k=r.toLowerCase(); if (!seen[k]){ seen[k]=1; uniq.push(r); } }
-
-      function weight(line){
-        if (line.indexOf("⟦INTENT⟧") === 0) return 1000;
-        if (line.indexOf("⟦TASK⟧") === 0)   return 900;
-        if (line.indexOf("⟦CANON⟧") === 0)  return 800;
-        if (line.indexOf("⟦OPENING⟧") === 0)return 700;
-        if (line.indexOf("⟦SCENE⟧") === 0 && line.indexOf("Focus") !== -1) return 600;
-        if (line.indexOf("⟦SCENE⟧") === 0)  return 500;
-        if (line.indexOf("⟦GUIDE⟧") === 0)  return 400;
-        if (line.indexOf("⟦META⟧") === 0)   return 100;
-        return 0;
-      }
-      uniq.sort((a,b)=> weight(b) - weight(a));
-
-      const MAX = LC.CONFIG?.LIMITS?.CONTEXT_LENGTH ?? 800;
-      let overlay = "";
-      const parts = { GUIDE:0, INTENT:0, TASK:0, CANON:0, OPENING:0, SCENE:0, META:0 };
-      for (let i=0;i<uniq.length;i++){
-        const line = uniq[i];
-        const nl = overlay ? "\n" : "";
-        if ((overlay.length + line.length + nl.length) > MAX) continue;
-        overlay += nl + line;
-        const tag = (line.match(/^⟦([A-Z]+)⟧/)||[])[1] || "GUIDE";
-        parts[tag] = (parts[tag]||0) + line.length + nl.length;
-      }
-      return { overlay, parts, max:MAX };
-    }
-
     switch ((cmd.split(" ")[0])) {
       case "/help":
       case "/h":
@@ -472,21 +394,20 @@ const args   = tokens.slice(1);
       }
 
       case "/ctx": {
+        const limit = LC.CONFIG?.LIMITS?.CONTEXT_LENGTH ?? 800;
         let r;
         try {
-          if (typeof LC !== "undefined") {
-            const built = LC.buildCtxPreview?.(LC.lcInit?.());
-            if (built && typeof built === "object") r = built;
-          }
-        } catch (_) {/* fallback */}
-
+          r = LC.composeContextOverlay?.({ limit, allowPartial: true });
+        } catch (_) {/* ignore */}
         if (!r || typeof r !== "object") {
-          // Fallback to local preview builder
-          r = (typeof buildContextPreview === "function") ? buildContextPreview() : { overlay:"", max:800, parts:{} };
+          r = LC.buildCtxPreview?.({ limit, allowPartial: true });
         }
-        const overlay = (typeof r.overlay === "string") ? r.overlay : String(r.overlay || "");
-        const max = (typeof r.max === "number" && isFinite(r.max)) ? r.max : 800;
+        const overlayRaw = (r && typeof r.text === "string") ? r.text
+          : (typeof r?.overlay === "string") ? r.overlay
+          : String(r?.text ?? r?.overlay ?? "");
+        const max = (typeof r?.max === "number" && isFinite(r.max)) ? r.max : limit;
         const parts = (r.parts && typeof r.parts === "object") ? r.parts : {};
+        const overlay = overlayRaw.length > limit ? overlayRaw.slice(0, limit) : overlayRaw;
         const lines = [
           `LEN: ${overlay.length}/${max}`,
           `GUIDE: ${parts.GUIDE||0}`,

--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -1599,7 +1599,8 @@ LC.turnUndo = turnUndo;
 
 
 
-LC.buildCtxPreview = function() {
+LC.composeContextOverlay = function(options) {
+  const opts = (options && typeof options === "object") ? options : {};
   try {
     const L = LC.lcInit();
     const priority = [];
@@ -1664,22 +1665,48 @@ LC.buildCtxPreview = function() {
     }
     uniq.sort((a,b)=> weight(b) - weight(a));
 
-    const MAX = LC.CONFIG?.LIMITS?.CONTEXT_LENGTH ?? 800;
-    let overlay = "";
+    const MAX = Number.isFinite(Number(opts.limit)) ? Number(opts.limit) : (LC.CONFIG?.LIMITS?.CONTEXT_LENGTH ?? 800);
+    let text = "";
     const parts = { GUIDE:0, INTENT:0, TASK:0, CANON:0, OPENING:0, SCENE:0, META:0 };
     for (let i=0;i<uniq.length;i++){
       const line = uniq[i];
-      const nl = overlay ? "\n" : "";
-      if ((overlay.length + line.length + nl.length) > MAX) continue;
-      overlay += nl + line;
+      const nl = text ? "\n" : "";
+      const projectedLength = text.length + nl.length + line.length;
+      if (projectedLength > MAX) {
+        if (!opts.allowPartial) continue;
+        const currentLength = text.length + nl.length;
+        const remaining = MAX - currentLength;
+        if (remaining <= 0) break;
+        if (remaining >= 40) {
+          const slice = line.slice(0, remaining);
+          text += nl + slice;
+          const tag = (line.match(/^⟦([A-Z]+)⟧/)||[])[1] || "GUIDE";
+          parts[tag] = (parts[tag]||0) + nl.length + slice.length;
+        }
+        break;
+      }
+      text += nl + line;
       const tag = (line.match(/^⟦([A-Z]+)⟧/)||[])[1] || "GUIDE";
       parts[tag] = (parts[tag]||0) + line.length + nl.length;
     }
-    return { overlay, parts, max:MAX };
+    return { text, parts, max:MAX };
   } catch(e) {
     const err = e && e.message ? e.message : String(e);
-    return { overlay:"", parts:{}, max:0, error:err };
+    return { text:"", parts:{}, max:0, error:err };
   }
+};
+
+LC.buildCtxPreview = function(options) {
+  const result = LC.composeContextOverlay?.(options);
+  if (result && typeof result === "object") {
+    return {
+      overlay: typeof result.text === "string" ? result.text : String(result.text || ""),
+      parts: result.parts || {},
+      max: result.max,
+      error: result.error
+    };
+  }
+  return { overlay:"", parts:{}, max:0 };
 };
 
 


### PR DESCRIPTION
## Summary
- add an LC.composeContextOverlay helper that assembles the overlay text and statistics with optional partial truncation
- reuse the shared helper from the context modifier and /ctx command to ensure a single source of logic and consistent trimming

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dd5765b240832987fc879ef69d9945