### PR TITLE
Use replyStop for UI and debug command toggles

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -136,13 +136,13 @@ const args   = tokens.slice(1);
         ].join("\n"));
 
       case "/ui":
-        if (/\/ui\s+on/i.test(cmdRaw))  { L.sysShow = true;  return reply("✅ UI enabled."); }
-        if (/\/ui\s+off/i.test(cmdRaw)) { L.sysShow = false; return reply("⚫ UI disabled."); }
+        if (/\/ui\s+on/i.test(cmdRaw))  { L.sysShow = true;  return replyStop("✅ UI enabled."); }
+        if (/\/ui\s+off/i.test(cmdRaw)) { L.sysShow = false; return replyStop("⚫ UI disabled."); }
         return replyStop(`UI is ${L.sysShow ? "on" : "off"}.`);
 
       case "/debug":
-        if (/\/debug\s+on/i.test(cmdRaw))  { L.debugMode = true;  return reply("🔍 Debug ON."); }
-        if (/\/debug\s+off/i.test(cmdRaw)) { L.debugMode = false; return reply("🔍 Debug OFF."); }
+        if (/\/debug\s+on/i.test(cmdRaw))  { L.debugMode = true;  return replyStop("🔍 Debug ON."); }
+        if (/\/debug\s+off/i.test(cmdRaw)) { L.debugMode = false; return replyStop("🔍 Debug OFF."); }
         return replyStop(`Debug is ${L.debugMode ? "on" : "off"}.`);
 
       case "/recap":


### PR DESCRIPTION
## Summary
- update /ui and /debug command handlers to respond via replyStop
- ensure toggling these commands no longer triggers model output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de0d4512dc8329ab7cd0fa2db2482a