### PR TITLE
Add command registry bootstrap and integrate parser fallback

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -108,6 +108,16 @@ const args   = tokens.slice(1);
       return reply("🕑 Recap later (3 turns).");
     }
 
+    // Registry first
+    try {
+      const reg = LC.Commands?.get(cmd);
+      if (reg && typeof reg.handler === "function") {
+        return reg.handler(args, text);
+      }
+    } catch(e) {
+      return replyStop(`Command failed: ${e?.message||e}`);
+    }
+
     switch ((cmd.split(" ")[0])) {
       case "/help":
       case "/h":

--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -131,6 +131,11 @@ Contract:
     return v;
   };
 
+  // RF-T5: Commands registry (minimal start)
+  LC.Commands ??= new Map();
+  if (!LC.Commands.has("/help"))  LC.Commands.set("/help",  { bypass: true, handler: () => replyStop("Help shown.") });
+  if (!LC.Commands.has("/stats")) LC.Commands.set("/stats", { bypass: true, handler: () => replyStop("Stats shown.") });
+
   // FNV-1a 32-bit (умножение на prime через сумму сдвигов — эквивалент Math.imul(h, 0x01000193))
   const FNV1A = (str) => {
     let h = 0x811c9dc5 >>> 0;


### PR DESCRIPTION
## Summary
- initialize a commands registry in the library with default /help and /stats handlers
- update the input parser to consult the registry before falling back to legacy switch handling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68de0e248b948329a64c916d612f5b42