### PR TITLE
Add standardized contract headers to patched modules

### DIFF
--- a/Context v16.0.8.patched.txt
+++ b/Context v16.0.8.patched.txt
@@ -1,10 +1,11 @@
-﻿/* 
-Module: Context (Lincoln v16.0.8-compat6d)
+/*
+Module: Context — Lincoln v16.0.8-compat6d
 Contract:
-- Reads flags: ...; Writes flags: ...
+- Reads flags: ...
+- Writes flags: ...
 - Entry points: ...
-- Invariants: recap/epoch flags reset only on non-command path; retry baseline preserved; ...
-- Config keys used: CONTEXT_LENGTH, CHAR_WINDOW_*, LIMITS.ANTI_ECHO, FEATURES.*
+- Invariants: recap/epoch reset only on non-command path; retry baseline preserved; command bypass on marked handlers.
+- Config: LIMITS.*, CHAR_WINDOW_*, FEATURES.*, OUTPUT_BUDGET_MS (optional)
 */
 // === CONTEXT MODIFIER v16.0.8-compat6d ===
 const __SCRIPT_SLOT__ = "Context";

--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -1,10 +1,11 @@
-﻿/* 
-Module: Input (Lincoln v16.0.8-compat6d)
+/*
+Module: Input — Lincoln v16.0.8-compat6d
 Contract:
-- Reads flags: ...; Writes flags: ...
+- Reads flags: ...
+- Writes flags: ...
 - Entry points: ...
-- Invariants: recap/epoch flags reset only on non-command path; retry baseline preserved; ...
-- Config keys used: CONTEXT_LENGTH, CHAR_WINDOW_*, LIMITS.ANTI_ECHO, FEATURES.*
+- Invariants: recap/epoch reset only on non-command path; retry baseline preserved; command bypass on marked handlers.
+- Config: LIMITS.*, CHAR_WINDOW_*, FEATURES.*, OUTPUT_BUDGET_MS (optional)
 */
 // === INPUT MODIFIER v16.0.8-compat6d ===
 const __SCRIPT_SLOT__ = "Input";

--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -1,10 +1,11 @@
-﻿/* 
-Module: Library (Lincoln v16.0.8-compat6d)
+/*
+Module: Library — Lincoln v16.0.8-compat6d
 Contract:
-- Reads flags: ...; Writes flags: ...
+- Reads flags: ...
+- Writes flags: ...
 - Entry points: ...
-- Invariants: recap/epoch flags reset only on non-command path; retry baseline preserved; ...
-- Config keys used: CONTEXT_LENGTH, CHAR_WINDOW_*, LIMITS.ANTI_ECHO, FEATURES.*
+- Invariants: recap/epoch reset only on non-command path; retry baseline preserved; command bypass on marked handlers.
+- Config: LIMITS.*, CHAR_WINDOW_*, FEATURES.*, OUTPUT_BUDGET_MS (optional)
 */
 // === LIBRARY — Lincoln Heights Core v16.0.8-compat6d ===
 

--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -1,10 +1,11 @@
-﻿/* 
-Module: Output (Lincoln v16.0.8-compat6d)
+/*
+Module: Output — Lincoln v16.0.8-compat6d
 Contract:
-- Reads flags: ...; Writes flags: ...
+- Reads flags: ...
+- Writes flags: ...
 - Entry points: ...
-- Invariants: recap/epoch flags reset only on non-command path; retry baseline preserved; ...
-- Config keys used: CONTEXT_LENGTH, CHAR_WINDOW_*, LIMITS.ANTI_ECHO, FEATURES.*
+- Invariants: recap/epoch reset only on non-command path; retry baseline preserved; command bypass on marked handlers.
+- Config: LIMITS.*, CHAR_WINDOW_*, FEATURES.*, OUTPUT_BUDGET_MS (optional)
 */
 // === OUTPUT MODIFIER v16.0.8-compat6d ===
 const __SCRIPT_SLOT__ = "Output";


### PR DESCRIPTION
## Summary
- replace the existing header comments in the Context, Input, Library, and Output patched scripts with a standardized contract block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de14566150832988280121a10ebab9