### PR TITLE
Fix command registry stop reply fallback

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -134,8 +134,21 @@ Contract:
 
   // RF-T5: Commands registry (minimal start)
   LC.Commands ??= new Map();
-  if (!LC.Commands.has("/help"))  LC.Commands.set("/help",  { bypass: true, handler: () => replyStop("Help shown.") });
-  if (!LC.Commands.has("/stats")) LC.Commands.set("/stats", { bypass: true, handler: () => replyStop("Stats shown.") });
+
+  // Безопасный вызов stop-ответа: сначала пробуем экспорт из Input, иначе — локальный fallback-объект
+  function _safeCmd(msg){
+    if (typeof LC !== "undefined" && typeof LC.replyStop === "function") {
+      return LC.replyStop(msg);
+    }
+    return { text: (LC.CONFIG?.CMD_PLACEHOLDER ?? "⟦SYS⟧ OK."), stop: true, _sys: String(msg ?? "") };
+  }
+
+  if (!LC.Commands.has("/help")) {
+    LC.Commands.set("/help",  { bypass: true, handler: () => _safeCmd("Help shown.") });
+  }
+  if (!LC.Commands.has("/stats")) {
+    LC.Commands.set("/stats", { bypass: true, handler: () => _safeCmd("Stats shown.") });
+  }
 
   // FNV-1a 32-bit (умножение на prime через сумму сдвигов — эквивалент Math.imul(h, 0x01000193))
   const FNV1A = (str) => {


### PR DESCRIPTION
## Summary
- add a safe helper that uses LC.replyStop when available and falls back to a local response
- update the /help and /stats command handlers to rely on the new helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de18bba3d483298bc84c4ccacfb732