### PR TITLE
Export reply helpers for registry access

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -47,6 +47,9 @@ if (typeof LC === "undefined") return { text: String(text || "") };
     clearCommandFlags();
     return { text: LC.CONFIG?.CMD_PLACEHOLDER ?? "⟦SYS⟧ OK.", stop: true, _sys: msg };
   }
+  // Экспорт хелперов для registry в Library
+  LC.replyStop = replyStop;
+  LC.reply = reply;
 
   function extractCommand(s){
     let t = (s || "").trim();


### PR DESCRIPTION
## Summary
- expose `replyStop` and `reply` on the `LC` object for registry usage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68de1945d2d883299fb276d3d76711b2