### PR TITLE
Reorder LC retry flag initialization

### DIFF
--- a/Context v16.0.8.patched.txt
+++ b/Context v16.0.8.patched.txt
@@ -13,8 +13,9 @@ if (typeof LC !== "undefined") LC.DATA_VERSION = "16.0.8-compat6d";
 
 const modifier = function (text) {
   
-  const RETRY_KEEP_CONTEXT = (typeof LC !== 'undefined' && LC.lcGetFlag && (LC.lcGetFlag('RETRY_KEEP_CONTEXT', false) === true)); 
-if (typeof LC === "undefined") return { text: String(text || "") };
+  if (typeof LC === "undefined") return { text: String(text || "") };
+  LC.lcInit?.();
+  const RETRY_KEEP_CONTEXT = (LC.lcGetFlag?.('RETRY_KEEP_CONTEXT', false) === true);
   LC.DATA_VERSION = "16.0.8-compat6d";
   const L = LC.lcInit(__SCRIPT_SLOT__);
 


### PR DESCRIPTION
## Summary
- guard against undefined LC before proceeding and perform optional LC init
- read the RETRY_KEEP_CONTEXT flag after initialization for clearer flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68de1aef1b6c8329b49d7e9ab9961e97