### PR TITLE
docs: clarify registry helper exports

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -50,6 +50,7 @@ if (typeof LC === "undefined") return { text: String(text || "") };
   // Экспорт хелперов для registry в Library
   LC.replyStop = replyStop;
   LC.reply = reply;
+  // Обновляем ссылки при каждом запуске, чтобы registry всегда получал актуальные хелперы.
 
   function extractCommand(s){
     let t = (s || "").trim();


### PR DESCRIPTION
## Summary
- document that Input re-exports replyStop and reply for the registry to use

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68de1f7ff4a883299b51e4394c3ab73d