### PR TITLE
Ensure command registry uses safe stop fallback

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -132,7 +132,7 @@ Contract:
     return v;
   };
 
-  // RF-T5: Commands registry (minimal start)
+  // RF-T5: Commands registry (minimal start, safe replies)
   LC.Commands ??= new Map();
 
   // Безопасный вызов stop-ответа: сначала пробуем экспорт из Input, иначе — локальный fallback-объект


### PR DESCRIPTION
## Summary
- ensure the Library command registry is marked as using safe replies when invoking stop responses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de212633e08329a9bc016b5fd3735b