### PR TITLE
Clarify LC initialization before reading retry flag

### DIFF
--- a/Context v16.0.8.patched.txt
+++ b/Context v16.0.8.patched.txt
@@ -14,6 +14,8 @@ if (typeof LC !== "undefined") LC.DATA_VERSION = "16.0.8-compat6d";
 const modifier = function (text) {
   
   if (typeof LC === "undefined") return { text: String(text || "") };
+
+  // Run LC initialization before checking retry flags for clarity.
   LC.lcInit?.();
   const RETRY_KEEP_CONTEXT = (LC.lcGetFlag?.('RETRY_KEEP_CONTEXT', false) === true);
   LC.DATA_VERSION = "16.0.8-compat6d";


### PR DESCRIPTION
## Summary
- document the LC initialization call before checking retry flags in the context modifier
- keep behavior intact while making initialization order clearer

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68de2f425e088329afe7be1bf1efcee7