### PR TITLE
Use replyStop for evergreen manual set

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -201,7 +201,7 @@ const args   = tokens.slice(1);
           const target = allowed.indexOf(cat) === -1 ? "facts" : cat;
           const key = `u_${Date.now().toString(36)}`;
           LC.evergreenManualSet(L, target, key, val);
-          return reply(`Evergreen[${target}] += ${val.slice(0,80)}`);
+          return replyStop(`Evergreen[${target}] += ${val.slice(0,80)}`);
         }
         return replyStop(LC.autoEvergreen.getSummary());
       }


### PR DESCRIPTION
## Summary
- ensure the /evergreen set command returns via replyStop to prevent triggering the model

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68de5271e660832983e726ca97648dd3