### PR TITLE
Gate SYS notices behind sysShow

### DIFF
--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -114,8 +114,10 @@ const modifier = function (text) {
   const notices = LC.consumeNotices?.() || "";
   const msgs = LC.lcConsumeMsgs?.() || [];
   let final = out;
-  if (msgs.length) final = msgs.join("\n") + "\n" + "=".repeat(40) + "\n" + final;
-  if (notices) final = notices + "\n\n" + final;
+  if (L.sysShow) {
+    if (msgs.length) final = msgs.join("\n") + "\n" + "=".repeat(40) + "\n" + final;
+    if (notices) final = notices + "\n\n" + final;
+  }
   return { text: final };
 };
 return modifier(text);


### PR DESCRIPTION
## Summary
- wrap SYS notices and messages in a `L.sysShow` check so they only display when requested

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de578083148329bbad48288712d71b