### PR TITLE
Stop recap decline commands from triggering generation

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -98,14 +98,14 @@ const args   = tokens.slice(1);
         return replyStop('ℹ️ Нет активного оффера рекапа.');
       }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn + 5;
-      return reply("🚫 Recap postponed for 5 turns.");
+      return replyStop("🚫 Recap postponed for 5 turns.");
     }
     if (cmd === "/позже"){
       if (!(typeof LC !== 'undefined' && LC.lcGetFlag && LC.lcGetFlag('wantRecap', wantRecap))) {
         return replyStop('ℹ️ Нет активного оффера рекапа.');
       }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn + 3; if (L.tm) L.tm.wantRecapTurn = 0;
-      return reply("🕑 Recap later (3 turns).");
+      return replyStop("🕑 Recap later (3 turns).");
     }
 
     // Сначала пробуем registry


### PR DESCRIPTION
## Summary
- update the /нет and /позже recap offer handlers to use replyStop when an offer is active
- ensure these commands bypass model generation while keeping existing behavior when no offer is active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de5aba03f08329af7daa7c1d366411