### PR TITLE
Remove duplicate LC.Turns definition

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -1605,12 +1605,6 @@ L.debugMode = toBool(L.debugMode, false);
     queueEpoch(){ LC.lcSetFlag?.("doEpoch", true); },
   }, LC.Flags || {});
 
-  LC.Turns = LC.Turns || {
-    incIfNeeded(){ if (!LC.lcGetFlag?.("isCmd") && !LC.lcGetFlag?.("isRetry")) { const L=LC.lcInit(); L.turn=(L.turn|0)+1; } },
-    set(n){ LC.turnSet?.(n); },
-    undo(n){ LC.turnUndo?.(n); },
-  };
-
   if (typeof globalThis !== "undefined") globalThis.LC = LC;
   if (typeof window !== "undefined") window.LC = LC;
 })();


### PR DESCRIPTION
## Summary
- remove the redundant `LC.Turns = LC.Turns || { … }` block since `LC.Turns ??= { … }` already initializes the facade

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de5b9b5c188329b7af73c75a19a5ab