### PR TITLE
Gate SYS notices on retry

### DIFF
--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -150,7 +150,7 @@ const modifier = function (text) {
   const notices = LC.consumeNotices?.() || "";
   const msgs = LC.lcConsumeMsgs?.() || [];
   let final = out;
-  if (L.sysShow) {
+  if (L.sysShow && !isRetry) {
     if (msgs.length) final = msgs.join("\n") + "\n" + "=".repeat(40) + "\n" + final;
     if (notices) final = notices + "\n\n" + final;
   }


### PR DESCRIPTION
## Summary
- prevent SYS notices from appearing in normal output when the UI is disabled or the turn is a retry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dec2b9b43c8329bd62fe24041f43a9