### PR TITLE
Remove redundant early lcInit call

### DIFF
--- a/Context v16.0.8.patched.txt
+++ b/Context v16.0.8.patched.txt
@@ -15,8 +15,6 @@ const modifier = function (text) {
   
   if (typeof LC === "undefined") return { text: String(text || "") };
 
-  // Run LC initialization before checking retry flags for clarity.
-  LC.lcInit?.();
   const RETRY_KEEP_CONTEXT = (LC.lcGetFlag?.('RETRY_KEEP_CONTEXT', false) === true);
   LC.DATA_VERSION = "16.0.8-compat6d";
   const L = LC.lcInit(__SCRIPT_SLOT__);


### PR DESCRIPTION
## Summary
- remove the no-op optional lcInit invocation so only the slot-based initialization remains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68deda4095188329b9193fe74bd60b89