### PR TITLE
Ensure recap acceptance clears command flag

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -97,6 +97,7 @@ const args   = tokens.slice(1);
       }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn;
       LC.lcSetFlag("doRecap", true);
+      LC.Flags?.clearCmd?.(); // важно: снять isCmd до Context
       return reply("📋 Recap will be generated.");
     }
     if (cmd === "/нет")  {


### PR DESCRIPTION
## Summary
- clear the command flag when the /да quick reply schedules a recap

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68deddd87c0c8329a3f5c2c9d5c631ef