### PR TITLE
Ensure reply clears command flags

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -23,8 +23,12 @@ if (typeof LC === "undefined") return { text: String(text || "") };
   const userText = LC.stripYouWrappers(raw.trim());
 
   function reply(msg){
+    try { LC.lcInit?.(__SCRIPT_SLOT__); } catch(_) {}
+    // команды, идущие через reply (не stop), всё равно должны снять isCmd,
+    // иначе следующий этап воспримет ход как «командный»
+    LC.Flags?.clearCmd?.();
     LC.lcSys(msg);
-    return { text: LC.CONFIG?.CMD_PLACEHOLDER ?? "⟦SYS⟧ OK." };
+    return { text: LC.CONFIG?.CMD_PLACEHOLDER ?? "⟦SYS⟧ OK.", stop: false };
   }
   function clearCommandFlags(){
     try {


### PR DESCRIPTION
## Summary
- clear command flags when replying to command responses to avoid propagating command state
- preserve existing reply behavior while forcing lcInit initialization and explicit non-stop response

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dee0a0e5248329987a4009a04c236e