### PR TITLE
Add safety command flag reset in output modifier

### DIFF
--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -73,6 +73,7 @@ const modifier = function (text) {
   // Командный ответ: обработка /continue → SYS
   if (isCmd) {
     const msgs = LC.lcConsumeMsgs?.() || [];
+    LC.Flags?.clearCmd?.(); // страховочный сброс, чтобы не «залипнуть» в командном режиме
     return { text: (msgs.length ? msgs.join("\n") + "\n" + "=".repeat(40) + "\n" : (LC.CONFIG.CMD_PLACEHOLDER || "⟦SYS⟧ OK.") + "\n") };
   }
 


### PR DESCRIPTION
## Summary
- clear command flags before returning from command output path to avoid lingering command mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dee1e0853083299ec3863cf874bf02