### PR TITLE
Add early exit for pure command contexts

### DIFF
--- a/Context v16.0.8.patched.txt
+++ b/Context v16.0.8.patched.txt
@@ -19,10 +19,17 @@ const modifier = function (text) {
   LC.DATA_VERSION = "16.0.8-compat6d";
   const L = LC.lcInit(__SCRIPT_SLOT__);
 
-  const isRetry = LC.lcGetFlag("isRetry", false);
+  const isRetry = LC.lcGetFlag?.("isRetry", false) ?? false;
   if (isRetry && !RETRY_KEEP_CONTEXT) return { text: String(text || "") };
 
-  const isCmd = LC.lcGetFlag("isCmd", false);
+  const isCmd = LC.lcGetFlag?.("isCmd", false) ?? false;
+  const wantsRecap = LC.lcGetFlag?.("doRecap", false) ?? false;
+  const wantsEpoch = LC.lcGetFlag?.("doEpoch", false) ?? false;
+
+  // Если это чистая команда (нет задач на драфты) — не трать бюджет на сборку оверлея
+  if (isCmd && !wantsRecap && !wantsEpoch) {
+    return { text: String(text || "") };
+  }
 
   const limit = (LC.CONFIG && LC.CONFIG.LIMITS && LC.CONFIG.LIMITS.CONTEXT_LENGTH) || 800;
   const built = LC.composeContextOverlay?.({ limit, allowPartial: true });


### PR DESCRIPTION
## Summary
- add an early return to skip context overlay construction when handling pure command turns
- ensure command flag reads tolerate missing lcGetFlag implementation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dee32e1d5c8329855532fb86d73392