### PR TITLE
Add warning for command and task flag collision

### DIFF
--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -29,6 +29,10 @@ const modifier = function (text) {
   const wantsRecap = LC.lcGetFlag("doRecap", false);
   const wantsEpoch = LC.lcGetFlag("doEpoch", false);
 
+  if (LC.lcGetFlag?.("isCmd", false) && (LC.lcGetFlag?.("doRecap", false) || LC.lcGetFlag?.("doEpoch", false))) {
+    LC.lcWarn?.("Command+TASK collision: check /да handler clears isCmd before Context.");
+  }
+
   // T1: Accept drafts requested by /continue
   try {
     const wantAccept = LC.lcGetFlag?.("acceptDraft", false);


### PR DESCRIPTION
## Summary
- add a diagnostic warning when command output coincides with recap or epoch task flags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dee4ce35f48329bea3bc5e2b6c6c99