### PR TITLE
Reset recap flags on manual recap and epoch commands

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -179,10 +179,16 @@ const args   = tokens.slice(1);
         return replyStop(`Debug is ${L.debugMode ? "on" : "off"}.`);
 
       case "/recap":
+        LC.lcSetFlag("wantRecap", false);
+        L.tm = L.tm || {};
+        L.tm.wantRecapTurn = 0;
         LC.lcSetFlag("doRecap", true);
         return replyStop("📋 Recap requested. Next output → draft.");
 
       case "/epoch":
+        LC.lcSetFlag("wantRecap", false);
+        L.tm = L.tm || {};
+        L.tm.wantRecapTurn = 0;
         LC.lcSetFlag("doEpoch", true);
         return replyStop("🗿 Epoch requested. Next output → draft.");
 


### PR DESCRIPTION
## Summary
- clear the recap offer flag before scheduling a manual /recap
- apply the same reset to /epoch so it can replace an automatic offer without leaving stale state

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68dee958f5d08329b491f0d686080607