### PR TITLE
Sync lastProcessedTurn with current turn

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -1658,6 +1658,7 @@ function turnSet(n) {
   const L = this.lcInit();
   const v = Math.max(0, Math.floor(Number(n) || 0));
   L.turn = v;
+  L.lastProcessedTurn = v;
   if (L.lastRecapTurn && L.lastRecapTurn >= v) L.lastRecapTurn = 0;
   if (L.lastEpochTurn && L.lastEpochTurn >= v) L.lastEpochTurn = 0;
   if (Array.isArray(L.events)) {


### PR DESCRIPTION
## Summary
- ensure `turnSet` keeps `lastProcessedTurn` aligned with the current turn value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68df726e782c83299840c4182f92ee21