### PR TITLE
Fix command sys message duplication

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -22,6 +22,21 @@ if (typeof LC === "undefined") return { text: String(text || "") };
   const raw = String(text || "");
   const userText = LC.stripYouWrappers(raw.trim());
 
+  const CMD_SYS_PREFIX = "\u2063\u2063"; // invisible marker to tag command SYS messages
+  const CMD_SYS_META_SEP = "\u2062";
+
+  function stampCommandSysMessage(message) {
+    const turn = L?.turn ?? 0;
+    const seq = (L._cmdSysSeq = (L._cmdSysSeq || 0) + 1);
+    const text = String(message ?? "");
+    return {
+      raw: `${CMD_SYS_PREFIX}${turn}:${seq}${CMD_SYS_META_SEP}${text}`,
+      turn,
+      seq,
+      text
+    };
+  }
+
   function reply(msg){
     try { LC.lcInit?.(__SCRIPT_SLOT__); } catch(_) {}
     // команды, идущие через reply (не stop), всё равно должны снять isCmd,
@@ -43,9 +58,12 @@ if (typeof LC === "undefined") return { text: String(text || "") };
 function replyStop(msg){
   // Командные ответы: только SYS (без notice) + немедленный вывод текста
   try { LC.lcInit?.(__SCRIPT_SLOT__); } catch(_) {}
-  LC.lcSys(msg);              // лог/SYS-лента
+  const stamped = stampCommandSysMessage(msg);
+  LC.lcSys(stamped.raw);              // лог/SYS-лента (с невидимой меткой)
+  L._cmdSysSeen = { turn: stamped.turn, seq: stamped.seq };
+  LC.lcConsumeMsgs?.();       // немедленно очищаем очередь SYS-сообщений
   clearCommandFlags();        // сбросить isCmd/isRetry/isContinue
-  return { text: `⟦SYS⟧ ${String(msg || "")}`, stop: true };
+  return { text: `⟦SYS⟧ ${String(stamped.text || "")}`, stop: true };
 }
 function replyStopSilent(){
   // Без текста и без SYS-префикса — просто остановить генерацию и сбросить флаги

--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -23,6 +23,25 @@ const modifier = function (text) {
   let out = String(text || "").trim();
   const clean = LC.lcStripSys(out);
 
+  const CMD_SYS_PREFIX = "\u2063\u2063";
+  const CMD_SYS_META_SEP = "\u2062";
+
+  function decodeCommandSys(raw) {
+    if (typeof raw !== "string") return null;
+    if (!raw.startsWith(CMD_SYS_PREFIX)) return null;
+    const metaEnd = raw.indexOf(CMD_SYS_META_SEP, CMD_SYS_PREFIX.length);
+    if (metaEnd <= CMD_SYS_PREFIX.length) return null;
+    const meta = raw.slice(CMD_SYS_PREFIX.length, metaEnd);
+    const text = raw.slice(metaEnd + CMD_SYS_META_SEP.length);
+    const [turnStr, seqStr] = meta.split(":");
+    const turn = Number.parseInt(turnStr, 10);
+    const seq = Number.parseInt(seqStr, 10);
+    if (!Number.isFinite(turn) || !Number.isFinite(seq)) {
+      return { text };
+    }
+    return { text, turn, seq };
+  }
+
 
   const isCmd = LC.lcGetFlag("isCmd", false);
   const isRetry = LC.lcGetFlag("isRetry", false);
@@ -76,7 +95,10 @@ const modifier = function (text) {
 
   // Командный ответ: обработка /continue → SYS
   if (isCmd) {
-    const msgs = LC.lcConsumeMsgs?.() || [];
+    const msgs = (LC.lcConsumeMsgs?.() || []).map(msg => {
+      const decoded = decodeCommandSys(msg);
+      return decoded ? decoded.text : msg;
+    });
     LC.Flags?.clearCmd?.(); // страховочный сброс, чтобы не «залипнуть» в командном режиме
     return { text: (msgs.length ? msgs.join("\n") + "\n" + "=".repeat(40) + "\n" : (LC.CONFIG.CMD_PLACEHOLDER || "⟦SYS⟧ OK.") + "\n") };
   }
@@ -153,7 +175,45 @@ const modifier = function (text) {
   const budget = omBudget(t0, LC.CONFIG?.LIMITS?.OUTPUT_BUDGET_MS ?? 3500);
   if (budget.over) LC.lcWarn?.(`Output budget exceeded: ${budget.dt}ms`);
   const notices = LC.consumeNotices?.() || "";
-  const msgs = LC.lcConsumeMsgs?.() || [];
+  let msgs = LC.lcConsumeMsgs?.() || [];
+  if (msgs.length) {
+    const filtered = [];
+    let seenTurn = L._cmdSysSeen?.turn;
+    let seenSeq = L._cmdSysSeen?.seq;
+    let sawStamped = false;
+    for (const rawMsg of msgs) {
+      const decoded = decodeCommandSys(rawMsg);
+      if (!decoded || decoded.turn == null || decoded.seq == null) {
+        filtered.push(decoded ? decoded.text : rawMsg);
+        continue;
+      }
+      sawStamped = true;
+      const currentTurn = typeof decoded.turn === "number" ? decoded.turn : null;
+      const currentSeq = typeof decoded.seq === "number" ? decoded.seq : null;
+      const lastTurn = typeof seenTurn === "number" ? seenTurn : -Infinity;
+      const lastSeq = typeof seenSeq === "number" ? seenSeq : -Infinity;
+      const isStaleTurn = currentTurn < lastTurn;
+      const isSameTurn = currentTurn === lastTurn;
+      if (isStaleTurn || (isSameTurn && currentSeq <= lastSeq)) {
+        continue;
+      }
+      if (!isSameTurn && currentTurn < (L.turn ?? -Infinity)) {
+        continue;
+      }
+      if (!Number.isFinite(currentTurn) || !Number.isFinite(currentSeq)) {
+        continue;
+      }
+      if (currentTurn > lastTurn || (isSameTurn && currentSeq > lastSeq)) {
+        seenTurn = currentTurn;
+        seenSeq = currentSeq;
+      }
+      // командные сообщения уже были показаны напрямую -> пропускаем
+    }
+    if (sawStamped) {
+      L._cmdSysSeen = { turn: seenTurn, seq: seenSeq };
+    }
+    msgs = filtered;
+  }
   let final = out;
   if (L.sysShow && !isRetry) {
     if (msgs.length) final = msgs.join("\n") + "\n" + "=".repeat(40) + "\n" + final;


### PR DESCRIPTION
## Summary
- stamp command replies in the input modifier and immediately flush the SYS queue to avoid duplicate delivery
- teach the output modifier to strip stamped command messages from both command and narrative flows so stale replies do not surface later

## Testing
- node - <<'NODE' ... (simulated /help command)  
- node - <<'NODE' ... (simulated output rendering)


------
https://chatgpt.com/codex/tasks/task_b_68e2a8bbd35c83298ddd8d060815594c