### PR TITLE
Prevent command cycles from incrementing turns

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -24,6 +24,7 @@ if (typeof LC === "undefined") return { text: String(text || "") };
 
   const CMD_SYS_PREFIX = "\u2063\u2063"; // invisible marker to tag command SYS messages
   const CMD_SYS_META_SEP = "\u2062";
+  const CMD_CYCLE_FLAG = "__cmdCyclePending";
 
   function stampCommandSysMessage(message) {
     const turn = L?.turn ?? 0;
@@ -37,22 +38,30 @@ if (typeof LC === "undefined") return { text: String(text || "") };
     };
   }
 
+  function clearCommandFlags(options = {}) {
+    const preserveCycle = options && options.preserveCycle === true;
+    try {
+      LC.Flags?.clearCmd?.();
+    } catch (_) {}
+    if (!preserveCycle) {
+      try {
+        LC.lcSetFlag?.(CMD_CYCLE_FLAG, false);
+      } catch (_) {}
+    }
+  }
+
   function reply(msg){
     try { LC.lcInit?.(__SCRIPT_SLOT__); } catch(_) {}
     // команды, идущие через reply (не stop), всё равно должны снять isCmd,
     // иначе следующий этап воспримет ход как «командный»
-    LC.Flags?.clearCmd?.();
+    clearCommandFlags();
     LC.lcSys(msg);
     return { text: LC.CONFIG?.CMD_PLACEHOLDER ?? "⟦SYS⟧ OK.", stop: false };
-  }
-  function clearCommandFlags(){
-    try {
-      LC.Flags?.clearCmd?.();
-    } catch (_) {}
   }
   function setCommandMode(){
     try {
       LC.Flags?.setCmd?.();
+      LC.lcSetFlag?.(CMD_CYCLE_FLAG, true);
     } catch (_) {}
   }
 function replyStop(msg){
@@ -62,15 +71,56 @@ function replyStop(msg){
   LC.lcSys(stamped.raw);              // лог/SYS-лента (с невидимой меткой)
   L._cmdSysSeen = { turn: stamped.turn, seq: stamped.seq };
   LC.lcConsumeMsgs?.();       // немедленно очищаем очередь SYS-сообщений
-  clearCommandFlags();        // сбросить isCmd/isRetry/isContinue
+  try { LC.lcSetFlag?.(CMD_CYCLE_FLAG, true); } catch (_) {}
+  clearCommandFlags({ preserveCycle: true });        // сбросить isCmd/isRetry/isContinue, но сохранить признак цикла
   return { text: `⟦SYS⟧ ${String(stamped.text || "")}`, stop: true };
 }
 function replyStopSilent(){
   // Без текста и без SYS-префикса — просто остановить генерацию и сбросить флаги
   try { LC.lcInit?.(__SCRIPT_SLOT__); } catch(_) {}
-  clearCommandFlags();
+  try { LC.lcSetFlag?.(CMD_CYCLE_FLAG, true); } catch (_) {}
+  clearCommandFlags({ preserveCycle: true });
   return { text: "", stop: true };
 }
+
+  function handleAcceptDraftCycle(currentL = L) {
+    let processed = false;
+    try {
+      const wantAccept = LC.lcGetFlag?.("acceptDraft", false);
+      if (!wantAccept) return false;
+      LC.lcSetFlag?.("acceptDraft", false);
+      const activeL = currentL || LC?.lcInit?.(__SCRIPT_SLOT__) || L || {};
+
+      if (activeL.recapDraft && activeL.recapDraft.text) {
+        try {
+          let savedCount = 0;
+          if (typeof LC.syncRecapToStoryCards === "function") {
+            savedCount = LC.syncRecapToStoryCards(activeL.recapDraft.text, activeL.recapDraft.window) | 0;
+          }
+          activeL.lastRecapTurn = activeL.recapDraft.turn || activeL.turn;
+          activeL.recapDraft = null;
+          LC.lcSys?.(`✅ Recap saved${savedCount ? ` (${savedCount} card${savedCount===1?'':'s'})` : ""}.`);
+        } catch (e) {
+          LC.lcWarn?.("Recap save failed: " + (e && e.message));
+        }
+        processed = true;
+      }
+
+      if (activeL.epochDraft && activeL.epochDraft.text) {
+        try {
+          activeL.lastEpochTurn = activeL.epochDraft.turn || activeL.turn;
+          activeL.epochDraft = null;
+          LC.lcSys?.("✅ Epoch accepted.");
+        } catch (e) {
+          LC.lcWarn?.("Epoch accept failed: " + (e && e.message));
+        }
+        processed = true;
+      }
+    } catch (e) {
+      LC.lcWarn?.("AcceptDraft handling failed: " + (e && e.message));
+    }
+    return processed;
+  }
   // Экспорт для registry (Library)
   LC.replyStop = replyStop;
   LC.reply = reply;
@@ -176,7 +226,7 @@ const args   = tokens.slice(1);
     if (cmd === "/undo") {
       const n = Number(args[0] || 1);
       try { if (typeof LC !== 'undefined') LC.turnUndo(n); } catch(e) { try { LC.lcSys("⚠️ Undo failed."); } catch(_){} }
-      clearCommandFlags();
+      clearCommandFlags({ preserveCycle: true });
       return replyStop(`↩️ Undid ${n|0} turn${(n|0)===1?"":"s"}.`);
     }
 
@@ -184,7 +234,7 @@ const args   = tokens.slice(1);
     if (cmd === "/turn" && (args[0] || "").toLowerCase() === "set") {
       const n = Number(args[1] || 0);
       try { if (typeof LC !== 'undefined') LC.turnSet(n); } catch(e) { try { LC.lcSys("⚠️ Turn set failed."); } catch(_){} }
-      clearCommandFlags();
+      clearCommandFlags({ preserveCycle: true });
       return replyStop(`↩️ Turn set to ${n|0}.`);
     }
 
@@ -196,7 +246,7 @@ const args   = tokens.slice(1);
       }
       LC.lcSetFlag("wantRecap", false); L.recapMuteUntil = L.turn;
       LC.lcSetFlag("doRecap", true);
-      LC.Flags?.clearCmd?.(); // важно: снять isCmd до Context
+      clearCommandFlags({ preserveCycle: true }); // важно: снять isCmd до Context, но сохранить признак командного цикла
       return replyStop("📋 Recap will be generated.");
     }
     if (cmd === "/нет")  {
@@ -271,7 +321,11 @@ const args   = tokens.slice(1);
         return replyStop("🗿 Epoch requested. Next output → draft.");
 
       case "/continue":
-        if (L.recapDraft || L.epochDraft) { LC.lcSetFlag("acceptDraft", true); return replyStopSilent(); }
+        if (L.recapDraft || L.epochDraft) {
+          LC.lcSetFlag("acceptDraft", true);
+          handleAcceptDraftCycle();
+          return replyStopSilent();
+        }
         return replyStop("❌ No draft to save.");
 
       case "/evergreen": {

--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -25,6 +25,7 @@ const modifier = function (text) {
 
   const CMD_SYS_PREFIX = "\u2063\u2063";
   const CMD_SYS_META_SEP = "\u2062";
+  const CMD_CYCLE_FLAG = "__cmdCyclePending";
 
   function decodeCommandSys(raw) {
     if (typeof raw !== "string") return null;
@@ -44,9 +45,12 @@ const modifier = function (text) {
 
 
   const isCmd = LC.lcGetFlag("isCmd", false);
+  const cmdCyclePending = LC.lcGetFlag(CMD_CYCLE_FLAG, false);
   const isRetry = LC.lcGetFlag("isRetry", false);
   const wantsRecap = LC.lcGetFlag("doRecap", false);
   const wantsEpoch = LC.lcGetFlag("doEpoch", false);
+  const lastActionType = L.lastActionType || "";
+  const isCommandAction = lastActionType === "command" || cmdCyclePending || isCmd;
 
   if (LC.lcGetFlag?.("isCmd", false) && (LC.lcGetFlag?.("doRecap", false) || LC.lcGetFlag?.("doEpoch", false))) {
     LC.lcWarn?.("Command+TASK collision: check /да handler clears isCmd before Context.");
@@ -94,11 +98,12 @@ const modifier = function (text) {
   }
 
   // Командный ответ: обработка /continue → SYS
-  if (isCmd) {
+  if (isCmd || cmdCyclePending) {
     const msgs = (LC.lcConsumeMsgs?.() || []).map(msg => {
       const decoded = decodeCommandSys(msg);
       return decoded ? decoded.text : msg;
     });
+    try { LC.lcSetFlag?.(CMD_CYCLE_FLAG, false); } catch (_) {}
     LC.Flags?.clearCmd?.(); // страховочный сброс, чтобы не «залипнуть» в командном режиме
     return { text: (msgs.length ? msgs.join("\n") + "\n" + "=".repeat(40) + "\n" : (LC.CONFIG.CMD_PLACEHOLDER || "⟦SYS⟧ OK.") + "\n") };
   }
@@ -107,16 +112,15 @@ const modifier = function (text) {
   if (wantsEpoch) LC.lcSetFlag("doEpoch", false);
 
   // Инкремент хода на реальном действии
-  if (!isRetry && LC.shouldIncrementTurn()) {
+  if (!isRetry && !isCommandAction && LC.shouldIncrementTurn()) {
     LC.incrementTurn();
   }
   L.lastOutput = clean;
 
   // Anti-echo
-  const actionType = L.lastActionType || "";
   let filtered = clean;
   if (!isRetry) {
-    filtered = LC.applyAntiEcho(clean, L.prevOutput, actionType);
+    filtered = LC.applyAntiEcho(clean, L.prevOutput, lastActionType);
     // Only update the anti-echo baseline when not retrying.
     L.prevOutput = filtered;
   }


### PR DESCRIPTION
## Summary
- keep a dedicated `__cmdCyclePending` flag in Input so command replies remain marked until Output finishes handling them
- process `/continue` acceptance directly in Input so drafts are saved even if the pipeline stops on `stop: true`
- teach Output to respect the command flag/`lastActionType` before incrementing the turn counter and to clear the pending flag when done

## Testing
- `node <<'NODE' ...` (runs `/help`, `/stats`, `/continue` through the modifiers to ensure the turn counter stays put and drafts are accepted)


------
https://chatgpt.com/codex/tasks/task_b_68e4b0061c008329bad802b1d7285350