### PR TITLE
Avoid SYS divider when queue empty

### DIFF
--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -102,13 +102,16 @@ const modifier = function (text) {
 
   // Командный ответ: обработка /continue → SYS
   if (isCmd || cmdCyclePending) {
-    const msgs = (LC.lcConsumeMsgs?.() || []).map(msg => {
+    const rawMsgs = LC.lcConsumeMsgs?.() || [];
+    const msgs = rawMsgs.map(msg => {
       const decoded = decodeCommandSys(msg);
       return decoded ? decoded.text : msg;
     });
     try { LC.lcSetFlag?.(CMD_CYCLE_FLAG, false); } catch (_) {}
     LC.Flags?.clearCmd?.(); // страховочный сброс, чтобы не «залипнуть» в командном режиме
-    return { text: (msgs.length ? msgs.join("\n") + "\n" + "=".repeat(40) + "\n" : (LC.CONFIG.CMD_PLACEHOLDER || "⟦SYS⟧ OK.") + "\n") };
+    if (!msgs.length) return { text: (LC.CONFIG.CMD_PLACEHOLDER || "⟦SYS⟧ OK.") + "\n" };
+    const body = msgs.join("\n");
+    return { text: body + (body ? "\n" + "=".repeat(40) + "\n" : "\n") };
   }
 
   if (wantsRecap) LC.lcSetFlag("doRecap", false);


### PR DESCRIPTION
## Summary
- ensure command outputs return the configured placeholder without a divider when the SYS queue is empty
- only append the separator when command messages produce a non-empty body

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e4d82c19448329ba7e40d395089675