### PR TITLE
Improve command SYS decoding and document audit findings

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,0 +1,30 @@
+# Lincoln v16.0.8-compat6d Script Audit
+
+## Methodology
+- Reviewed Context, Input, Output, and Library modules for shared versioning, exported APIs, and guard rails.
+- Traced cross-module flag flows (command cycle, recap/epoch scheduling, retry handling).
+- Inspected command handlers and evergreen/anti-echo utilities for edge cases.
+- Validated output pipeline for command SYS message delivery and telemetry side effects.
+
+## Compatibility Assessment
+- All three runtime modules explicitly align to the `16.0.8-compat6d` data version and re-register it during modifier execution, keeping downstream consumers in sync.【F:Context v16.0.8.patched.txt†L11-L40】【F:Input v16.0.8.patched.txt†L10-L26】【F:Output v16.0.8.patched.txt†L10-L57】
+- The Library bootstrap normalises any pre-existing `LC.CONFIG` object, merging limit/feature defaults so that older host environments keep working while allowing overrides from newer loaders.【F:Library v16.0.8.patched.txt†L28-L118】【F:Library v16.0.8.patched.txt†L1601-L1640】
+- Shared helpers such as `LC.replyStop`, `LC.Commands`, `LC.buildCtxPreview`, and evergreen utilities are exported centrally, and Input reuses them through guarded optional chaining to avoid hard crashes if the Library is missing or partially initialised.【F:Input v16.0.8.patched.txt†L53-L200】【F:Library v16.0.8.patched.txt†L44-L107】【F:Library v16.0.8.patched.txt†L763-L1407】
+
+## Logic Consistency Checks
+- Command handling keeps `isCmd`/`__cmdCyclePending` flags in lockstep: Input sets them before routing to handlers, clears them on replies, and Output honours the cycle to present SYS transcripts while preventing unintended turn increments.【F:Input v16.0.8.patched.txt†L25-L84】【F:Input v16.0.8.patched.txt†L186-L200】【F:Output v16.0.8.patched.txt†L26-L121】 
+- Recap/epoch workflows are coordinated: Input toggles `doRecap`/`doEpoch` and queues acceptance, Output persists drafts and resets flags, and Library tracks cadence, offers, and acceptance telemetry to avoid infinite loops.【F:Input v16.0.8.patched.txt†L315-L335】【F:Output v16.0.8.patched.txt†L68-L160】【F:Library v16.0.8.patched.txt†L123-L575】【F:Library v16.0.8.patched.txt†L1400-L1550】
+- Evergreen, anti-echo, and event scoring use consistent limits sourced from `LC.CONFIG`, ensuring user commands stay within guard rails and telemetry doesn’t leak across sessions.【F:Input v16.0.8.patched.txt†L332-L405】【F:Library v16.0.8.patched.txt†L763-L1335】【F:Library v16.0.8.patched.txt†L1400-L1485】
+
+## Defects Identified & Fixes
+- **Command SYS decoding bug (fixed):** Output previously failed to strip the default `⟦SYS⟧` wrapper that `LC.lcSys` adds before attempting to parse stamped command messages, so stamped turn/sequence metadata was never recognised. `decodeCommandSys` now removes the wrapper before validating the invisible marker, restoring duplicate suppression and clean transcript rendering.【F:Input v16.0.8.patched.txt†L67-L76】【F:Library v16.0.8.patched.txt†L318-L323】【F:Output v16.0.8.patched.txt†L26-L121】
+- No additional blocking bugs were observed. Context overlay fallbacks, anti-echo trimming, and evergreen history caps all degrade gracefully when upstream services are unavailable, limiting the blast radius to informational warnings.【F:Context v16.0.8.patched.txt†L27-L44】【F:Output v16.0.8.patched.txt†L132-L160】【F:Library v16.0.8.patched.txt†L763-L1387】
+
+## Functional Verification
+- **Command surface:** `/evergreen`, `/antiecho`, `/events`, `/alias`, `/story`, `/cards`, `/ctx`, `/retry`, and `/cadence` handlers validate input, call shared Library helpers, and return SYS responses to keep the UI responsive without leaking command state into narrative turns.【F:Input v16.0.8.patched.txt†L332-L520】
+- **Turn management & retries:** Library exposes `turnSet`, `turnUndo`, automatic turn increment, retry counters, and anti-echo caches so Output can safely increment turns only on story actions while keeping retry/continue semantics intact.【F:Library v16.0.8.patched.txt†L300-L575】【F:Output v16.0.8.patched.txt†L126-L158】
+- **Context composition:** `LC.composeContextOverlay` builds prioritised overlays that respect limit budgets, incorporate intent/evergreen/canon slices, and gracefully degrade on errors, ensuring the Context modifier can fall back to upstream text when overlay building fails.【F:Context v16.0.8.patched.txt†L27-L44】【F:Library v16.0.8.patched.txt†L1660-L1770】
+
+## Recommendations
+- Maintain the new SYS decoding guard if further wrappers are introduced (e.g., localisation tags) by keeping the trim logic tolerant to alternative prefixes.
+- Consider adding lightweight automated tests (even mocked Node harnesses) for `decodeCommandSys`, anti-echo caching, and evergreen command flows to prevent regressions across future compatibility patches.

--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -29,11 +29,17 @@ const modifier = function (text) {
 
   function decodeCommandSys(raw) {
     if (typeof raw !== "string") return null;
-    if (!raw.startsWith(CMD_SYS_PREFIX)) return null;
-    const metaEnd = raw.indexOf(CMD_SYS_META_SEP, CMD_SYS_PREFIX.length);
+    const SYS_PREFIX = "⟦SYS⟧";
+    let source = raw;
+    if (source.startsWith(SYS_PREFIX)) {
+      const trimmed = source.slice(SYS_PREFIX.length).trimStart();
+      source = trimmed.length ? trimmed : source;
+    }
+    if (!source.startsWith(CMD_SYS_PREFIX)) return null;
+    const metaEnd = source.indexOf(CMD_SYS_META_SEP, CMD_SYS_PREFIX.length);
     if (metaEnd <= CMD_SYS_PREFIX.length) return null;
-    const meta = raw.slice(CMD_SYS_PREFIX.length, metaEnd);
-    const text = raw.slice(metaEnd + CMD_SYS_META_SEP.length);
+    const meta = source.slice(CMD_SYS_PREFIX.length, metaEnd);
+    const text = source.slice(metaEnd + CMD_SYS_META_SEP.length);
     const [turnStr, seqStr] = meta.split(":");
     const turn = Number.parseInt(turnStr, 10);
     const seq = Number.parseInt(seqStr, 10);


### PR DESCRIPTION
## Summary
- fix the Output modifier so stamped command SYS messages are decoded even when wrapped by the default prefix
- add an audit report covering compatibility, logic flow, and functional checks for the Lincoln v16.0.8-compat6d scripts

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e4e3e00f4c8329a18734352be657a8