### PR TITLE
Prevent soft continue from incrementing turn

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -395,7 +395,8 @@ L.debugMode = toBool(L.debugMode, false);
       const isRetry = this.lcGetFlag("isRetry", false);
       const isCmd   = this.lcGetFlag("isCmd", false);
       const isContinue = this.lcGetFlag("isContinue", false);
-      return !isCmd && !(isRetry && !isContinue);
+      // increment only on real story input, not on retry and not on soft continue
+      return !isCmd && !isRetry && !isContinue;
     },
     incrementTurn(){
       const L = this.lcInit();

--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -58,7 +58,9 @@ const modifier = function (text) {
   // Derive lastActionType for analysis
   const lastActionType =
     (L && L.lastActionType) ||
-    (isRetry ? "retry" : (LC.lcGetFlag?.("isCmd", false) ? "command" : "story"));
+    (isRetry ? "retry"
+             : (LC.lcGetFlag?.("isContinue", false) ? "continue"
+                : (LC.lcGetFlag?.("isCmd", false) ? "command" : "story")));
   const isCommandAction = lastActionType === "command" || cmdCyclePending || isCmd;
 
   if (LC.lcGetFlag?.("isCmd", false) && (LC.lcGetFlag?.("doRecap", false) || LC.lcGetFlag?.("doEpoch", false))) {


### PR DESCRIPTION
## Summary
- ensure turn increments only for real story input and not for retry or soft continue actions
- extend lastActionType derivation to recognize continue events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e561b92f388329af2ec56719b01c26