### PR TITLE
Prioritize registry command handlers and remove local help/stats copies

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -214,14 +214,34 @@ const args   = tokens.slice(1);
 
   // ==== Команды ====
   if (cmd) {
-    setCommandMode();
-    L.lastActionType = "command";
-
 
     const wantRecap = LC.lcGetFlag("wantRecap", false);
 
     ensureSharedCommand("/help", buildHelpMessage);
+    ensureSharedCommand("/h", buildHelpMessage);
     ensureSharedCommand("/stats", buildStatsMessage);
+
+    // Try registry first
+    const def = LC.Commands?.get(cmd);
+    if (def && typeof def.handler === "function") {
+      if (def.bypass === true) {
+        LC.lcSetFlag?.("isCmd", true);
+        L.lastActionType = "command";
+      } else {
+        setCommandMode();
+        L.lastActionType = "command";
+      }
+      try {
+        const res = def.handler(args, text);
+        return res;
+      } catch (e) {
+        return replyStop(`Command failed: ${e?.message || e}`);
+      }
+    }
+
+    setCommandMode();
+    L.lastActionType = "command";
+
 // /undo [N]
     if (cmd === "/undo") {
       const n = Number(args[0] || 1);
@@ -264,27 +284,7 @@ const args   = tokens.slice(1);
       return replyStop("🕑 Recap later (3 turns).");
     }
 
-    // Сначала пробуем registry
-    try {
-      const def = LC.Commands?.get(cmd);
-      if (def && typeof def.handler === "function") {
-        // honor bypass: не меняем ход, не логируем ничего кроме ответа
-        const res = def.handler(args, text);
-        if (def.bypass) {
-          // гарантируем командный цикл и отсутствие побочных эффектов
-          LC.lcSetFlag?.("isCmd", true);
-        }
-        return res;
-      }
-    } catch (e) {
-      return replyStop(`Command failed: ${e?.message || e}`);
-    }
-
     switch ((cmd.split(" ")[0])) {
-      case "/help":
-      case "/h":
-        return replyStop(buildHelpMessage(L));
-
       case "/ui":
         if (/\/ui\s+on/i.test(cmdRaw)) {
           L.sysShow = true;
@@ -483,11 +483,6 @@ const args   = tokens.slice(1);
           `isRetry=${LC.lcGetFlag("isRetry", false)}, isContinue=${LC.lcGetFlag("isContinue", false)}`,
           `Keep context: ${keep ? "ON" : "OFF"}`
         ].join("\n"));
-      }
-
-
-      case "/stats": {
-        return replyStop(buildStatsMessage(L));
       }
 
       case "/cadence": {


### PR DESCRIPTION
## Summary
- dispatch commands through the LC.Commands registry before local handling and respect bypass semantics
- register shared help aliases and remove the local /help and /stats switch branches so registry implementations take precedence

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e5650477dc8329bfb7e8b5f06a4fd1