### PR TITLE
Silence command output placeholder after stop

### DIFF
--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -117,9 +117,12 @@ const modifier = function (text) {
     });
     try { LC.lcSetFlag?.(CMD_CYCLE_FLAG, false); } catch (_) {}
     LC.Flags?.clearCmd?.(); // страховочный сброс, чтобы не «залипнуть» в командном режиме
-    if (!msgs.length) return { text: (LC.CONFIG.CMD_PLACEHOLDER || "⟦SYS⟧ OK.") + "\n" };
+    if (!msgs.length) {
+      // Командный ответ уже был показан на Input-стадии → молчим
+      return { text: "" };
+    }
     const body = msgs.join("\n");
-    return { text: body + (body ? "\n" + "=".repeat(40) + "\n" : "\n") };
+    return { text: body + "\n" + "=".repeat(40) + "\n" };
   }
 
   if (wantsRecap) LC.lcSetFlag("doRecap", false);


### PR DESCRIPTION
## Summary
- suppress command placeholder output when the command queue has already been flushed
- retain standard separator formatting only when messages exist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e57a534f488329a480e76aa901901a