### PR TITLE
Preserve bypass semantics when overriding commands

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -185,17 +185,20 @@ function replyStopSilent(){
 
   function ensureSharedCommand(cmdName, builder) {
     if (!LC?.Commands) return;
-    const existing = LC.Commands.get(cmdName);
+    const existing = LC.Commands?.get?.(cmdName);
     if (existing && !existing.bypass && typeof existing.handler === "function") {
       return;
     }
+    const prev = existing;
+    const bypass = (prev && prev.bypass === true) || false;
     LC.Commands.set(cmdName, {
       handler() {
         const ctx = LC?.lcInit?.(__SCRIPT_SLOT__) || LC?.lcInit?.() || L;
         const message = builder(ctx);
         if (typeof LC.replyStop === "function") return LC.replyStop(message);
         return { text: `⟦SYS⟧ ${String(message ?? "")}`, stop: true };
-      }
+      },
+      bypass
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure command overrides retain the bypass flag if it was previously set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e57b837d8483299325f808c996d70c