### PR TITLE
Sanitize alias entries on updates

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -422,13 +422,19 @@ const args   = tokens.slice(1);
           const name = m[1].trim();
           const list = m[2].split(",").map(s=>s.trim()).filter(Boolean);
           L.aliases[name] = list;
-          return replyStop(`Alias set: ${name} = ${list.join(", ")}`);
+          LC.sanitizeAliases?.(L);
+          const finalList = Array.isArray(L.aliases[name]) ? L.aliases[name] : [];
+          return replyStop(`Alias set: ${name} = ${finalList.join(", ")}`);
         }
         if (/\/alias\s+del\s+/i.test(cmdRaw)) {
           const m = cmdRaw.match(/\/alias\s+del\s+(.+)$/i);
           if (!m) return replyStop("Usage: /alias del <Name>");
           const name = m[1].trim();
-          if (name in L.aliases) { delete L.aliases[name]; return replyStop(`Alias deleted: ${name}`); }
+          if (name in L.aliases) {
+            delete L.aliases[name];
+            LC.sanitizeAliases?.(L);
+            return replyStop(`Alias deleted: ${name}`);
+          }
           return replyStop(`No alias for: ${name}`);
         }
         return replyStop("Usage: /alias add <Name>=a,b,c | /alias del <Name> | /alias list");

--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -55,6 +55,32 @@ Contract:
     STRICT_CMD_BYPASS: true
   };
 
+  LC.sanitizeAliases = function sanitizeAliases(L){
+    try {
+      if (!L) return;
+      if (!Array.isArray(L.aliases) && L.aliases && typeof L.aliases === "object") {
+        for (const key in L.aliases) {
+          if (!Object.prototype.hasOwnProperty.call(L.aliases, key)) continue;
+          const wrap = { aliases: L.aliases[key] };
+          sanitizeAliases(wrap);
+          L.aliases[key] = wrap.aliases;
+        }
+        return;
+      }
+      const src = Array.isArray(L.aliases) ? L.aliases : [];
+      const uniq = [];
+      const seen = new Set();
+      for (let i=0;i<src.length;i++){
+        const v = String(src[i] || "").trim().toLowerCase();
+        if (!v) continue;
+        if (seen.has(v)) continue;
+        seen.add(v);
+        uniq.push(v);
+      }
+      L.aliases = uniq;
+    } catch(_) {}
+  };
+
   // Notices (centralized)
   LC.pushNotice ??= (msg) => {
     if (!msg) return;


### PR DESCRIPTION
## Summary
- add LC.sanitizeAliases helper to normalize alias arrays
- invoke sanitization after /alias add and /alias del operations to keep entries lowercase and deduplicated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e57c9272388329a34d69f6548ccb1c