### PR TITLE
Update replyStopSilent to mark command cycle without SYS output

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -76,10 +76,10 @@ function replyStop(msg){
   return { text: `⟦SYS⟧ ${String(stamped.text || "")}`, stop: true };
 }
 function replyStopSilent(){
-  // Без текста и без SYS-префикса — просто остановить генерацию и сбросить флаги
   try { LC.lcInit?.(__SCRIPT_SLOT__); } catch(_) {}
-  try { LC.lcSetFlag?.(CMD_CYCLE_FLAG, true); } catch (_) {}
-  clearCommandFlags({ preserveCycle: true });
+  // помечаем командный цикл, но не кладём ничего в SYS-очередь
+  LC.lcSetFlag?.("isCmd", true);
+  // НЕ пишем SYS и НЕ ставим плейсхолдер — Output вернёт пустую строку
   return { text: "", stop: true };
 }
 


### PR DESCRIPTION
## Summary
- ensure replyStopSilent marks the command cycle without writing to the SYS queue
- rely on Output returning an empty string when no SYS messages are queued

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e57e4c10a483299952d98f9de288f2