### PR TITLE
Unify draft acceptance via shared helper

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -83,44 +83,6 @@ function replyStopSilent(){
   return { text: "", stop: true };
 }
 
-  function handleAcceptDraftCycle(currentL = L) {
-    let processed = false;
-    try {
-      const wantAccept = LC.lcGetFlag?.("acceptDraft", false);
-      if (!wantAccept) return false;
-      LC.lcSetFlag?.("acceptDraft", false);
-      const activeL = currentL || LC?.lcInit?.(__SCRIPT_SLOT__) || L || {};
-
-      if (activeL.recapDraft && activeL.recapDraft.text) {
-        try {
-          let savedCount = 0;
-          if (typeof LC.syncRecapToStoryCards === "function") {
-            savedCount = LC.syncRecapToStoryCards(activeL.recapDraft.text, activeL.recapDraft.window) | 0;
-          }
-          activeL.lastRecapTurn = activeL.recapDraft.turn || activeL.turn;
-          activeL.recapDraft = null;
-          LC.lcSys?.(`✅ Recap saved${savedCount ? ` (${savedCount} card${savedCount===1?'':'s'})` : ""}.`);
-        } catch (e) {
-          LC.lcWarn?.("Recap save failed: " + (e && e.message));
-        }
-        processed = true;
-      }
-
-      if (activeL.epochDraft && activeL.epochDraft.text) {
-        try {
-          activeL.lastEpochTurn = activeL.epochDraft.turn || activeL.turn;
-          activeL.epochDraft = null;
-          LC.lcSys?.("✅ Epoch accepted.");
-        } catch (e) {
-          LC.lcWarn?.("Epoch accept failed: " + (e && e.message));
-        }
-        processed = true;
-      }
-    } catch (e) {
-      LC.lcWarn?.("AcceptDraft handling failed: " + (e && e.message));
-    }
-    return processed;
-  }
   // Экспорт для registry (Library)
   LC.replyStop = replyStop;
   LC.reply = reply;
@@ -326,8 +288,9 @@ const args   = tokens.slice(1);
 
       case "/continue":
         if (L.recapDraft || L.epochDraft) {
-          LC.lcSetFlag("acceptDraft", true);
-          handleAcceptDraftCycle();
+          // Гарантированно применяем драфты на стадии Input (идемпотентность внутри)
+          LC.lcSetFlag?.("isCmd", true);
+          LC.Drafts?.applyPending?.(L, "input");
           return replyStopSilent();
         }
         return replyStop("❌ No draft to save.");

--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -100,6 +100,63 @@ Contract:
     clearCmd(){ LC.lcSetFlag?.("isCmd", false); LC.lcSetFlag?.("isRetry", false); LC.lcSetFlag?.("isContinue", false); }
   };
 
+  LC.applyRecapDraft ??= function applyRecapDraft(L) {
+    if (!L || !L.recapDraft || !L.recapDraft.text) return false;
+    let savedCount = 0;
+    if (typeof LC.syncRecapToStoryCards === "function") {
+      try {
+        savedCount = LC.syncRecapToStoryCards(L.recapDraft.text, L.recapDraft.window) | 0;
+      } catch (e) {
+        LC.lcWarn?.("syncRecapToStoryCards failed: " + (e && e.message));
+      }
+    }
+    L.lastRecapTurn = L.recapDraft.turn || L.turn;
+    L.recapDraft = null;
+    LC.lcSys?.(`✅ Recap saved${savedCount ? ` (${savedCount} card${savedCount === 1 ? "" : "s"})` : ""}.`);
+    return { savedCount };
+  };
+
+  LC.applyEpochDraft ??= function applyEpochDraft(L) {
+    if (!L || !L.epochDraft || !L.epochDraft.text) return false;
+    L.lastEpochTurn = L.epochDraft.turn || L.turn;
+    L.epochDraft = null;
+    LC.lcSys?.("✅ Epoch accepted.");
+    return true;
+  };
+
+  LC.Drafts = LC.Drafts || {};
+  LC.Drafts.applyPending = function applyPending(L, source){
+    try {
+      if (!L) return { applied:false, reason:"no-state" };
+      if (L.__draftAppliedStamp === L.turn) return { applied:false, reason:"already-applied" };
+
+      let did = false, notes=[];
+      if (L.recapDraft) {
+        // ваш текущий код «принять recapDraft» (перенос в карточки, метки lastRecapTurn и т.д.)
+        try {
+          const recapResult = LC.applyRecapDraft?.(L);
+          if (recapResult) { did = true; notes.push("recap"); }
+        } catch(e) { LC.lcWarn?.("applyRecapDraft: "+e?.message); }
+      }
+      if (L.epochDraft) {
+        // ваш текущий код «принять epochDraft»
+        try {
+          const epochResult = LC.applyEpochDraft?.(L);
+          if (epochResult) { did = true; notes.push("epoch"); }
+        } catch(e) { LC.lcWarn?.("applyEpochDraft: "+e?.message); }
+      }
+      if (did) {
+        L.__draftAppliedStamp = L.turn;
+        LC.lcSys?.("✅ Draft saved ("+notes.join("+")+")");
+        return { applied:true, notes };
+      }
+      return { applied:false, reason:"no-draft" };
+    } catch(e) {
+      LC.lcWarn?.("Drafts.applyPending failed: "+(e && e.message));
+      return { applied:false, reason:"error" };
+    }
+  };
+
   // Turns facade (тонкая обёртка)
   LC.Turns ??= {
     incIfNeeded(){ if (!LC.lcGetFlag?.("isCmd") && !LC.lcGetFlag?.("isRetry")) { const L=LC.lcInit(); L.turn=(L.turn|0)+1; } },

--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -67,41 +67,7 @@ const modifier = function (text) {
     LC.lcWarn?.("Command+TASK collision: check /да handler clears isCmd before Context.");
   }
 
-  // T1: Accept drafts requested by /continue
-  try {
-    const wantAccept = LC.lcGetFlag?.("acceptDraft", false);
-    if (wantAccept) {
-      LC.lcSetFlag?.("acceptDraft", false);
-
-      // Recap draft
-      if (L.recapDraft && L.recapDraft.text) {
-        try {
-          let savedCount = 0;
-          if (typeof LC.syncRecapToStoryCards === "function") {
-            savedCount = LC.syncRecapToStoryCards(L.recapDraft.text, L.recapDraft.window) | 0;
-          }
-          L.lastRecapTurn = L.recapDraft.turn || L.turn;
-          L.recapDraft = null;
-          LC.lcSys?.(`✅ Recap saved${savedCount ? ` (${savedCount} card${savedCount===1?'':'s'})` : ""}.`);
-        } catch (e) {
-          LC.lcWarn?.("Recap save failed: " + (e && e.message));
-        }
-      }
-
-      // Epoch draft
-      if (L.epochDraft && L.epochDraft.text) {
-        try {
-          L.lastEpochTurn = L.epochDraft.turn || L.turn;
-          L.epochDraft = null;
-          LC.lcSys?.("✅ Epoch accepted.");
-        } catch (e) {
-          LC.lcWarn?.("Epoch accept failed: " + (e && e.message));
-        }
-      }
-    }
-  } catch (e) {
-    LC.lcWarn?.("AcceptDraft handling failed: " + (e && e.message));
-  }
+  try { LC.Drafts?.applyPending?.(L, "output"); } catch(_) {}
 
   // Opening — первичный захват
   if (L.turn === 0 && !L.openingCaptured && !isRetry && clean.length > 20) {
@@ -109,6 +75,7 @@ const modifier = function (text) {
   }
 
   // Командный ответ: обработка /continue → SYS
+  try { LC.Drafts?.applyPending?.(L, "output"); } catch(_) {}
   if (isCmd || cmdCyclePending) {
     const rawMsgs = LC.lcConsumeMsgs?.() || [];
     const msgs = rawMsgs.map(msg => {


### PR DESCRIPTION
## Summary
- add shared LC.Drafts.applyPending helper with recap and epoch handlers to centralize draft saves
- update /continue command to rely on the shared helper and ensure input-stage idempotent acceptance
- invoke the shared helper from output processing to cover command and normal reply paths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e604ab4a388329baa545712bd8a0fd