### PR TITLE
Add turn invariant assertions before increment

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -474,6 +474,18 @@ L.debugMode = toBool(L.debugMode, false);
       return inputType;
     },
 
+    assertTurnInvariants(L, ctx){
+      try {
+        const isCmd = LC.lcGetFlag?.("isCmd", false);
+        const isRetry = LC.lcGetFlag?.("isRetry", false);
+        const isContinue = LC.lcGetFlag?.("isContinue", false);
+        const should = LC.shouldIncrementTurn?.() === true;
+        if (isCmd && should) LC.lcWarn?.("[TURN] would increment on command @"+ctx);
+        if (isRetry && should) LC.lcWarn?.("[TURN] would increment on retry @"+ctx);
+        if (isContinue && should) LC.lcWarn?.("[TURN] would increment on continue @"+ctx);
+      } catch(_) {}
+    },
+
     shouldIncrementTurn(){
       const isRetry = this.lcGetFlag("isRetry", false);
       const isCmd   = this.lcGetFlag("isCmd", false);

--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -95,6 +95,7 @@ const modifier = function (text) {
   if (wantsRecap) LC.lcSetFlag("doRecap", false);
   if (wantsEpoch) LC.lcSetFlag("doEpoch", false);
 
+  LC.assertTurnInvariants?.(L, "output:pre-inc");
   // Инкремент хода на реальном действии
   if (!isRetry && !isCommandAction && LC.shouldIncrementTurn()) {
     LC.incrementTurn();


### PR DESCRIPTION
## Summary
- add LC.assertTurnInvariants helper to warn about invalid turn increments
- invoke the invariant check before output-stage turn increment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e609af27d48329b8e7b3bd2bce200d