### PR TITLE
Deduplicate evergreen cue facts

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -1086,8 +1086,22 @@ L.debugMode = toBool(L.debugMode, false);
                 }
               }
             }
-            this.limitCategories?.(L);
           }
+          // Dedup facts by normalized text
+          try{
+            const cat = (L.evergreen && L.evergreen.facts) || {};
+            const keys = Object.keys(cat);
+            const seen = new Set();
+            for (let i=0;i<keys.length;i++){
+              const k = keys[i];
+              const v = String(cat[k]||"").trim().toLowerCase();
+              if (!v) { delete cat[k]; continue; }
+              if (seen.has(v)) { delete cat[k]; continue; }
+              seen.add(v);
+            }
+            LC.autoEvergreen?.limitCategories?.(L);
+          }catch(_){}
+        }
         } catch (e) {
           LC.lcWarn?.("EVG: factsCues analyze failed: " + (e && e.message));
         }


### PR DESCRIPTION
## Summary
- deduplicate cue-derived evergreen facts by normalized value
- remove empty entries and reapply evergreen category limits after deduplication

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e6292920448329b032488154d883e0