### PR TITLE
Consolidate LC.Flags initialization

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -107,9 +107,25 @@ Contract:
   };
 
   // Flags facade
-  LC.Flags ??= {
-    setCmd(){ LC.lcSetFlag?.("isCmd", true); LC.lcSetFlag?.("isRetry", false); LC.lcSetFlag?.("isContinue", false); },
-    clearCmd(){ LC.lcSetFlag?.("isCmd", false); LC.lcSetFlag?.("isRetry", false); LC.lcSetFlag?.("isContinue", false); }
+  LC.Flags ||= {};
+  LC.Flags.clearCmd ||= function clearCmd(preserveCycle){
+    try {
+      if (!preserveCycle) LC.lcSetFlag?.("__cmdCyclePending", false);
+      LC.lcSetFlag?.("isCmd", false);
+      LC.lcSetFlag?.("isRetry", false);
+      LC.lcSetFlag?.("isContinue", false);
+    } catch(_) {}
+  };
+  LC.Flags.setCmd ||= function setCmd(){
+    LC.lcSetFlag?.("isCmd", true);
+    LC.lcSetFlag?.("isRetry", false);
+    LC.lcSetFlag?.("isContinue", false);
+  };
+  LC.Flags.queueRecap ||= function queueRecap(){
+    LC.lcSetFlag?.("doRecap", true);
+  };
+  LC.Flags.queueEpoch ||= function queueEpoch(){
+    LC.lcSetFlag?.("doEpoch", true);
   };
 
   // --- SYS formatting helpers (shared by Input/Output) ---
@@ -1774,14 +1790,6 @@ L.debugMode = toBool(L.debugMode, false);
   } else if (_globalScope && typeof _globalScope === "object") {
     _globalScope.LC = LC;
   }
-
-  // ===== Flags API (non-breaking) =====
-  LC.Flags = Object.assign({
-    setCmd(){ LC.lcSetFlag?.("isCmd", true); LC.lcSetFlag?.("isRetry", false); LC.lcSetFlag?.("isContinue", false); },
-    clearCmd(){ LC.lcSetFlag?.("isCmd", false); LC.lcSetFlag?.("isRetry", false); LC.lcSetFlag?.("isContinue", false); },
-    queueRecap(){ LC.lcSetFlag?.("doRecap", true); },
-    queueEpoch(){ LC.lcSetFlag?.("doEpoch", true); },
-  }, LC.Flags || {});
 
   if (typeof globalThis !== "undefined") globalThis.LC = LC;
   if (typeof window !== "undefined") window.LC = LC;


### PR DESCRIPTION
## Summary
- add an early LC.Flags facade that preserves command-cycle flags via clearCmd
- keep the LC.Flags helper methods defined in a single location and remove the later duplication

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e683f7cb788329a357c6032f2cda03