### PR TITLE
Ensure command output queue is drained

### DIFF
--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -83,6 +83,11 @@ const modifier = function (text) {
     if (!msgs.length) return { text: "" }; // Командный ответ уже был показан на Input-стадии → молчим
 
     const body = LC.sysBlock?.(msgs) || (msgs.join("\n") + "\n");
+    // Очередь должен быть пустой после вывода
+    try {
+      const left = LC.lcConsumeMsgs?.() || [];
+      if (left.length) LC.lcWarn?.("SYS queue not empty after command cycle, purged " + left.length);
+    } catch(_) {}
     return { text: body };
   }
 


### PR DESCRIPTION
## Summary
- ensure command-cycle output drains remaining system messages and warns if residual entries are found

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e6867e3ce8832992af4fc8cb3d83b3