### PR TITLE
Ensure alias lists are sanitized after edits

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -57,39 +57,13 @@ Contract:
 
   LC.sanitizeAliases = function (L){
     try{
-      if (!L || !L.aliases) return;
-      if (Array.isArray(L.aliases)) {
-        const arr = L.aliases;
-        const seen = new Set();
-        const clean = [];
-        for (let i=0;i<arr.length;i++){
-          const v = String(arr[i]||"").trim().toLowerCase();
-          if (!v || seen.has(v)) continue;
-          seen.add(v);
-          clean.push(v);
-        }
-        L.aliases = clean;
-        return;
+      const arr = Array.isArray(L?.aliases) ? L.aliases : [];
+      const seen = new Set(); const clean = [];
+      for (let i=0;i<arr.length;i++){
+        const v = String(arr[i]||"").trim().toLowerCase();
+        if (!v || seen.has(v)) continue; seen.add(v); clean.push(v);
       }
-      if (typeof L.aliases === "object") {
-        const map = L.aliases;
-        for (const key of Object.keys(map)) {
-          const arr = Array.isArray(map[key]) ? map[key] : [];
-          const seen = new Set();
-          const clean = [];
-          for (let i=0;i<arr.length;i++){
-            const v = String(arr[i]||"").trim().toLowerCase();
-            if (!v || seen.has(v)) continue;
-            seen.add(v);
-            clean.push(v);
-          }
-          if (clean.length) {
-            map[key] = clean;
-          } else {
-            delete map[key];
-          }
-        }
-      }
+      L.aliases = clean;
     }catch(_){}
   };
 


### PR DESCRIPTION
## Summary
- replace LC.sanitizeAliases with a helper that normalizes, trims, and deduplicates alias entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e689edb83c8329a08d1ab6054839dd