### PR TITLE
Improve command queue handling and refresh audit

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,30 +1,30 @@
 # Lincoln v16.0.8-compat6d Script Audit
 
 ## Methodology
-- Reviewed Context, Input, Output, and Library modules for shared versioning, exported APIs, and guard rails.
-- Traced cross-module flag flows (command cycle, recap/epoch scheduling, retry handling).
-- Inspected command handlers and evergreen/anti-echo utilities for edge cases.
-- Validated output pipeline for command SYS message delivery and telemetry side effects.
+- Re-ran a manual audit of Library, Input, Output, and Context modules with an emphasis on cross-module contracts, state flows, and command-cycle safety.
+- Stepped through recap/epoch, evergreen, anti-echo, and SYS queue paths to confirm flag transitions and side effects across modifier stages.
+- Simulated common commands (undo, continue, cadence, evergreen toggles) by reading the handler implementations to validate turn logic and queue behaviour.
 
 ## Compatibility Assessment
-- All three runtime modules explicitly align to the `16.0.8-compat6d` data version and re-register it during modifier execution, keeping downstream consumers in sync.【F:Context v16.0.8.patched.txt†L11-L40】【F:Input v16.0.8.patched.txt†L10-L26】【F:Output v16.0.8.patched.txt†L10-L57】
-- The Library bootstrap normalises any pre-existing `LC.CONFIG` object, merging limit/feature defaults so that older host environments keep working while allowing overrides from newer loaders.【F:Library v16.0.8.patched.txt†L28-L118】【F:Library v16.0.8.patched.txt†L1601-L1640】
-- Shared helpers such as `LC.replyStop`, `LC.Commands`, `LC.buildCtxPreview`, and evergreen utilities are exported centrally, and Input reuses them through guarded optional chaining to avoid hard crashes if the Library is missing or partially initialised.【F:Input v16.0.8.patched.txt†L53-L200】【F:Library v16.0.8.patched.txt†L44-L107】【F:Library v16.0.8.patched.txt†L763-L1407】
+- All runtime modifiers still self-identify as `16.0.8-compat6d` and push the shared data version into `LC.DATA_VERSION` on every invocation, keeping mixed-loader environments on a consistent schema.【F:Context v16.0.8.patched.txt†L10-L49】【F:Input v16.0.8.patched.txt†L10-L208】【F:Output v16.0.8.patched.txt†L10-L91】
+- The Library bootstrap merges host-provided configuration with built-in defaults before exposing helpers, preserving backwards compatibility while respecting overrides for limits and features.【F:Library v16.0.8.patched.txt†L28-L118】【F:Library v16.0.8.patched.txt†L1727-L1767】
+- Shared helpers (`LC.replyStop`, `LC.Commands`, `LC.buildCtxPreview`, evergreen/anti-echo utilities) remain guarded with optional chaining and Map wrappers so that missing modules degrade gracefully instead of throwing runtime errors.【F:Input v16.0.8.patched.txt†L25-L208】【F:Library v16.0.8.patched.txt†L58-L220】
 
 ## Logic Consistency Checks
-- Command handling keeps `isCmd`/`__cmdCyclePending` flags in lockstep: Input sets them before routing to handlers, clears them on replies, and Output honours the cycle to present SYS transcripts while preventing unintended turn increments.【F:Input v16.0.8.patched.txt†L25-L84】【F:Input v16.0.8.patched.txt†L186-L200】【F:Output v16.0.8.patched.txt†L26-L121】 
-- Recap/epoch workflows are coordinated: Input toggles `doRecap`/`doEpoch` and queues acceptance, Output persists drafts and resets flags, and Library tracks cadence, offers, and acceptance telemetry to avoid infinite loops.【F:Input v16.0.8.patched.txt†L315-L335】【F:Output v16.0.8.patched.txt†L68-L160】【F:Library v16.0.8.patched.txt†L123-L575】【F:Library v16.0.8.patched.txt†L1400-L1550】
-- Evergreen, anti-echo, and event scoring use consistent limits sourced from `LC.CONFIG`, ensuring user commands stay within guard rails and telemetry doesn’t leak across sessions.【F:Input v16.0.8.patched.txt†L332-L405】【F:Library v16.0.8.patched.txt†L763-L1335】【F:Library v16.0.8.patched.txt†L1400-L1485】
+- Command cycle flags now propagate correctly: `clearCommandFlags` forwards the `preserveCycle` hint to the Library facade, allowing `/undo` and similar flows to keep `__cmdCyclePending` alive when requested.【F:Input v16.0.8.patched.txt†L71-L88】【F:Library v16.0.8.patched.txt†L83-L97】
+- Recap/Epoch orchestration remains coherent—Input toggles `doRecap`/`doEpoch`, Output clears them after generating drafts, and the Library owns cadence, auto-offer logic, and draft persistence with turn guards.【F:Input v16.0.8.patched.txt†L303-L323】【F:Output v16.0.8.patched.txt†L48-L133】【F:Library v16.0.8.patched.txt†L118-L166】【F:Library v16.0.8.patched.txt†L1400-L1552】
+- Turn bookkeeping and retry detection continue to rely on Library helpers (`detectInputType`, `shouldIncrementTurn`, `incrementTurn`), preventing inadvertent turn bumps on command or retry paths and warning when invariants would break.【F:Library v16.0.8.patched.txt†L452-L516】【F:Output v16.0.8.patched.txt†L97-L132】
 
-## Defects Identified & Fixes
-- **Command SYS decoding bug (fixed):** Output previously failed to strip the default `⟦SYS⟧` wrapper that `LC.lcSys` adds before attempting to parse stamped command messages, so stamped turn/sequence metadata was never recognised. `decodeCommandSys` now removes the wrapper before validating the invisible marker, restoring duplicate suppression and clean transcript rendering.【F:Input v16.0.8.patched.txt†L67-L76】【F:Library v16.0.8.patched.txt†L318-L323】【F:Output v16.0.8.patched.txt†L26-L121】
-- No additional blocking bugs were observed. Context overlay fallbacks, anti-echo trimming, and evergreen history caps all degrade gracefully when upstream services are unavailable, limiting the blast radius to informational warnings.【F:Context v16.0.8.patched.txt†L27-L44】【F:Output v16.0.8.patched.txt†L132-L160】【F:Library v16.0.8.patched.txt†L763-L1387】
+## Bugs & Conflicts Identified
+- **Command cycle preservation (fixed):** `clearCommandFlags` previously ignored the `preserveCycle` option and always cleared `__cmdCyclePending`, so chained command handlers lost their bypass state. Passing the hint through to `LC.Flags.clearCmd` keeps multi-step flows on the command path.【F:Input v16.0.8.patched.txt†L71-L88】【F:Library v16.0.8.patched.txt†L83-L97】
+- **Silent `/continue` confirmation (fixed):** `replyStopSilent` emptied the SYS queue even when `LC.Drafts.applyPending` enqueued success notices, causing `/continue` to apply drafts without user feedback. The helper now supports `keepQueue`, and the handler flushes stale entries before invoking the drafts API so Output can surface the confirmation block.【F:Input v16.0.8.patched.txt†L98-L106】【F:Input v16.0.8.patched.txt†L317-L323】【F:Library v16.0.8.patched.txt†L118-L166】【F:Output v16.0.8.patched.txt†L70-L91】
+- **Observation:** `stampCommandSysMessage` remains unused; if future work needs stamped SYS replay outside the command cycle, wire it into `replyStop` to leverage Output’s duplicate filter.【F:Input v16.0.8.patched.txt†L59-L76】【F:Output v16.0.8.patched.txt†L26-L49】
 
 ## Functional Verification
-- **Command surface:** `/evergreen`, `/antiecho`, `/events`, `/alias`, `/story`, `/cards`, `/ctx`, `/retry`, and `/cadence` handlers validate input, call shared Library helpers, and return SYS responses to keep the UI responsive without leaking command state into narrative turns.【F:Input v16.0.8.patched.txt†L332-L520】
-- **Turn management & retries:** Library exposes `turnSet`, `turnUndo`, automatic turn increment, retry counters, and anti-echo caches so Output can safely increment turns only on story actions while keeping retry/continue semantics intact.【F:Library v16.0.8.patched.txt†L300-L575】【F:Output v16.0.8.patched.txt†L126-L158】
-- **Context composition:** `LC.composeContextOverlay` builds prioritised overlays that respect limit budgets, incorporate intent/evergreen/canon slices, and gracefully degrade on errors, ensuring the Context modifier can fall back to upstream text when overlay building fails.【F:Context v16.0.8.patched.txt†L27-L44】【F:Library v16.0.8.patched.txt†L1660-L1770】
+- **Command surface:** `/evergreen`, `/antiecho`, `/events`, `/alias`, `/story`, `/cards`, `/ctx`, `/retry`, and `/cadence` continue to validate arguments, route through Library utilities, and respond with SYS-formatted text without incrementing story turns.【F:Input v16.0.8.patched.txt†L327-L520】
+- **Draft acceptance UX:** `/continue` now relays draft acceptance feedback via Output’s command branch, ensuring players see “✅ Draft saved …” confirmations when recaps or epochs are stored.【F:Input v16.0.8.patched.txt†L317-L323】【F:Library v16.0.8.patched.txt†L118-L166】【F:Output v16.0.8.patched.txt†L70-L91】
+- **Context composition & evergreen cadence:** `LC.composeContextOverlay` and evergreen analyzers respect configuration caps and degrade gracefully when upstream data is missing, keeping partial functionality intact on degraded hosts.【F:Context v16.0.8.patched.txt†L34-L49】【F:Library v16.0.8.patched.txt†L763-L1515】【F:Library v16.0.8.patched.txt†L182-L220】
 
 ## Recommendations
-- Maintain the new SYS decoding guard if further wrappers are introduced (e.g., localisation tags) by keeping the trim logic tolerant to alternative prefixes.
-- Consider adding lightweight automated tests (even mocked Node harnesses) for `decodeCommandSys`, anti-echo caching, and evergreen command flows to prevent regressions across future compatibility patches.
+- Add lightweight integration tests (or a scripted harness) for command-cycle toggles and the `/continue` draft flow so SYS queue regressions are caught early.
+- Consider wiring `stampCommandSysMessage` into `replyStop` when multi-message command responses are introduced, enabling Output’s dedupe guard for queued SYS lines.

--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -71,7 +71,7 @@ if (typeof LC === "undefined") return { text: String(text || "") };
   function clearCommandFlags(options = {}) {
     const preserveCycle = options && options.preserveCycle === true;
     try {
-      LC.Flags?.clearCmd?.();
+      LC.Flags?.clearCmd?.(preserveCycle);
     } catch (_) {}
     if (!preserveCycle) {
       try {
@@ -95,11 +95,14 @@ function replyStop(msg){
   try { LC.lcConsumeMsgs?.(); } catch(_) {}
   return { text: line ? line + "\n" : "", stop: true };
 }
-function replyStopSilent(){
+function replyStopSilent(options = {}){
   try { LC.lcInit?.(__SCRIPT_SLOT__); } catch(_) {}
   LC.lcSetFlag?.("isCmd", true);
-  // Никаких SYS и плейсхолдеров — Output вернет пусто при пустой очереди
-  try { LC.lcConsumeMsgs?.(); } catch(_) {}
+  const keepQueue = options && options.keepQueue === true;
+  if (!keepQueue) {
+    // Никаких SYS и плейсхолдеров — Output вернет пусто при пустой очереди
+    try { LC.lcConsumeMsgs?.(); } catch(_) {}
+  }
   return { text: "", stop: true };
 }
 
@@ -315,8 +318,9 @@ const args   = tokens.slice(1);
         if (L.recapDraft || L.epochDraft) {
           // Гарантированно применяем драфты на стадии Input (идемпотентность внутри)
           LC.lcSetFlag?.("isCmd", true);
+          try { LC.lcConsumeMsgs?.(); } catch(_) {}
           LC.Drafts?.applyPending?.(L, "input");
-          return replyStopSilent();
+          return replyStopSilent({ keepQueue: true });
         }
         return replyStop("❌ No draft to save.");
 


### PR DESCRIPTION
## Summary
- forward the preserveCycle hint when clearing command flags and keep draft confirmations in the SYS queue
- flush stale command messages before applying drafts and allow replyStopSilent to retain the queue when needed
- refresh the audit report with the new findings, fixes, and verification notes

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e695eba4448329876fe0901f537527