### PR TITLE
Treat Continue inputs as turn increments

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -504,9 +504,8 @@ L.debugMode = toBool(L.debugMode, false);
     shouldIncrementTurn(){
       const isRetry = this.lcGetFlag("isRetry", false);
       const isCmd   = this.lcGetFlag("isCmd", false);
-      const isContinue = this.lcGetFlag("isContinue", false);
-      // increment only on real story input, not on retry and not on soft continue
-      return !isCmd && !isRetry && !isContinue;
+      // теперь: Continue = реальный ход; +1 только если не команда и не retry
+      return !isCmd && !isRetry;
     },
     incrementTurn(){
       const L = this.lcInit();


### PR DESCRIPTION
## Summary
- allow Continue inputs to count as real turns while still skipping commands and retries

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e6e2ed93a08329805dc8343ea3c0db