### PR TITLE
Adjust turn increment logic for continue

### DIFF
--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -96,7 +96,7 @@ const modifier = function (text) {
 
   LC.assertTurnInvariants?.(L, "output:pre-inc");
   // Инкремент хода на реальном действии
-  if (!isRetry && !isCommandAction && LC.shouldIncrementTurn()) {
+  if (!isRetry && !LC.lcGetFlag?.("isCmd", false) && LC.shouldIncrementTurn()) {
     LC.incrementTurn();
   }
   L.lastOutput = clean;


### PR DESCRIPTION
## Summary
- adjust the turn increment guard to avoid blocking continues while still skipping command retries

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e6e3b1dcc48329a0d4767c472b15a9