### PR TITLE
Add turn invariant warnings for command/retry increments

### DIFF
--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -474,15 +474,13 @@ L.debugMode = toBool(L.debugMode, false);
     },
 
     assertTurnInvariants(L, ctx){
-      try {
+      try{
         const isCmd = LC.lcGetFlag?.("isCmd", false);
         const isRetry = LC.lcGetFlag?.("isRetry", false);
-        const isContinue = LC.lcGetFlag?.("isContinue", false);
         const should = LC.shouldIncrementTurn?.() === true;
-        if (isCmd && should) LC.lcWarn?.("[TURN] would increment on command @"+ctx);
-        if (isRetry && should) LC.lcWarn?.("[TURN] would increment on retry @"+ctx);
-        if (isContinue && should) LC.lcWarn?.("[TURN] would increment on continue @"+ctx);
-      } catch(_) {}
+        if (isCmd && should)  LC.lcWarn?.("[TURN] would increment on command @"+ctx);
+        if (isRetry && should)LC.lcWarn?.("[TURN] would increment on retry @"+ctx);
+      }catch(_){ }
     },
 
     shouldIncrementTurn(){


### PR DESCRIPTION
## Summary
- tighten `LC.assertTurnInvariants` so only command and retry paths warn about unexpected turn increments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e74b4c2c6483298c6de1bf17cef37a