### PR TITLE
Normalize aliases after add/remove commands

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -407,6 +407,7 @@ const args   = tokens.slice(1);
           if (!m) return replyStop("Usage: /alias add <Name>=a,b,c");
           const name = m[1].trim();
           const list = m[2].split(",").map(s=>s.trim()).filter(Boolean);
+          L.aliases = (L.aliases && typeof L.aliases === "object") ? L.aliases : {};
           L.aliases[name] = list;
           LC.sanitizeAliases?.(L);
           const finalList = Array.isArray(L.aliases[name]) ? L.aliases[name] : [];
@@ -416,6 +417,7 @@ const args   = tokens.slice(1);
           const m = cmdRaw.match(/\/alias\s+del\s+(.+)$/i);
           if (!m) return replyStop("Usage: /alias del <Name>");
           const name = m[1].trim();
+          L.aliases = (L.aliases && typeof L.aliases === "object") ? L.aliases : {};
           if (name in L.aliases) {
             delete L.aliases[name];
             LC.sanitizeAliases?.(L);

--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -57,13 +57,36 @@ Contract:
 
   LC.sanitizeAliases = function (L){
     try{
-      const arr = Array.isArray(L?.aliases) ? L.aliases : [];
-      const seen = new Set(); const clean = [];
-      for (let i=0;i<arr.length;i++){
-        const v = String(arr[i]||"").trim().toLowerCase();
-        if (!v || seen.has(v)) continue; seen.add(v); clean.push(v);
+      if (!L) return;
+      const aliases = L.aliases;
+      if (Array.isArray(aliases)){
+        const seen = new Set(); const clean = [];
+        for (let i=0;i<aliases.length;i++){
+          const v = String(aliases[i] ?? "").trim().toLowerCase();
+          if (!v || seen.has(v)) continue;
+          seen.add(v); clean.push(v);
+        }
+        L.aliases = clean;
+        return;
       }
-      L.aliases = clean;
+      if (aliases && typeof aliases === "object"){
+        const cleanMap = {};
+        for (const key of Object.keys(aliases)){
+          const safeKey = String(key ?? "").trim();
+          if (!safeKey) continue;
+          const arr = Array.isArray(aliases[key]) ? aliases[key] : [];
+          const seen = new Set(); const clean = [];
+          for (let i=0;i<arr.length;i++){
+            const v = String(arr[i] ?? "").trim().toLowerCase();
+            if (!v || seen.has(v)) continue;
+            seen.add(v); clean.push(v);
+          }
+          if (clean.length) cleanMap[safeKey] = clean;
+        }
+        L.aliases = cleanMap;
+        return;
+      }
+      L.aliases = {};
     }catch(_){}
   };
 


### PR DESCRIPTION
## Summary
- add LC.sanitizeAliases helper to deduplicate and normalize alias entries
- sanitize alias data after add/delete commands and ensure alias storage is initialized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e74edb7d24832983aed611d2083821