### PR TITLE
Preserve command bypass flags

### DIFF
--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -169,7 +169,7 @@ function replyStopSilent(){
     if (existing && !existing.bypass && typeof existing.handler === "function") {
       return;
     }
-    const prev = existing;
+    const prev = LC.Commands?.get?.(cmdName);
     const bypass = (prev && prev.bypass === true) || false;
     LC.Commands.set(cmdName, {
       handler() {
@@ -229,6 +229,11 @@ const args   = tokens.slice(1);
 
     setCommandMode();
     L.lastActionType = "command";
+
+    if (def?.bypass) {
+      LC.lcSetFlag?.("isCmd", true);
+      L.lastActionType = "command";
+    }
 
 // /undo [N]
     if (cmd === "/undo") {


### PR DESCRIPTION
## Summary
- ensure shared command registration retains the bypass flag from any existing command definition
- force bypassed commands to mark the turn as a command before falling back to local handlers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e7520b35188329afec96dd1f025d2f