### PR TITLE
Update docs for turn handling invariants

### DIFF
--- a/Context v16.0.8.patched.txt
+++ b/Context v16.0.8.patched.txt
@@ -4,7 +4,11 @@ Contract:
 - Reads flags: ...
 - Writes flags: ...
 - Entry points: ...
-- Invariants: recap/epoch reset only on non-command path; retry baseline preserved; command bypass on marked handlers.
+- Invariants:
+  - Turn +1 on story input and the UI Continue button.
+  - Turn +0 on slash commands (including `/continue`) and retries.
+  - `/continue` slash command accepts recap/epoch drafts (not the UI button).
+  - Context overlay falls back to upstream text when empty or on error.
 - Config: LIMITS.*, CHAR_WINDOW_*, FEATURES.*, OUTPUT_BUDGET_MS (optional)
 */
 // === CONTEXT MODIFIER v16.0.8-compat6d ===

--- a/Input v16.0.8.patched.txt
+++ b/Input v16.0.8.patched.txt
@@ -4,7 +4,11 @@ Contract:
 - Reads flags: ...
 - Writes flags: ...
 - Entry points: ...
-- Invariants: recap/epoch reset only on non-command path; retry baseline preserved; command bypass on marked handlers.
+- Invariants:
+  - Turn +1 on story input and the UI Continue button.
+  - Turn +0 on slash commands (including `/continue`) and retries.
+  - `/continue` slash command accepts recap/epoch drafts (not the UI button).
+  - Context overlay falls back to upstream text when empty or on error.
 - Config: LIMITS.*, CHAR_WINDOW_*, FEATURES.*, OUTPUT_BUDGET_MS (optional)
 */
 // === INPUT MODIFIER v16.0.8-compat6d ===

--- a/Library v16.0.8.patched.txt
+++ b/Library v16.0.8.patched.txt
@@ -4,7 +4,11 @@ Contract:
 - Reads flags: ...
 - Writes flags: ...
 - Entry points: ...
-- Invariants: recap/epoch reset only on non-command path; retry baseline preserved; command bypass on marked handlers.
+- Invariants:
+  - Turn +1 on story input and the UI Continue button.
+  - Turn +0 on slash commands (including `/continue`) and retries.
+  - `/continue` slash command accepts recap/epoch drafts (not the UI button).
+  - Context overlay falls back to upstream text when empty or on error.
 - Config: LIMITS.*, CHAR_WINDOW_*, FEATURES.*, OUTPUT_BUDGET_MS (optional)
 */
 // === LIBRARY — Lincoln Heights Core v16.0.8-compat6d ===

--- a/Output v16.0.8.patched.txt
+++ b/Output v16.0.8.patched.txt
@@ -4,7 +4,11 @@ Contract:
 - Reads flags: ...
 - Writes flags: ...
 - Entry points: ...
-- Invariants: recap/epoch reset only on non-command path; retry baseline preserved; command bypass on marked handlers.
+- Invariants:
+  - Turn +1 on story input and the UI Continue button.
+  - Turn +0 on slash commands (including `/continue`) and retries.
+  - `/continue` slash command accepts recap/epoch drafts (not the UI button).
+  - Context overlay falls back to upstream text when empty or on error.
 - Config: LIMITS.*, CHAR_WINDOW_*, FEATURES.*, OUTPUT_BUDGET_MS (optional)
 */
 // === OUTPUT MODIFIER v16.0.8-compat6d ===

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-This is my Ai Dungeon scritps
+# Lincoln scripts
+
+Internal notes for maintaining the Lincoln v16.0.8-compat6d script suite.
+
+## Turn accounting invariants
+
+- Normal player input and the UI **Continue** button each increment the turn counter (`+1`).
+- Slash commands (e.g. `/recap`, `/epoch`, `/continue`), retries, and the service `/continue` command leave the turn counter unchanged (`+0`).
+- The `/continue` slash command is the draft acceptance hook and must not be confused with the UI **Continue** button.
+
+## Context overlay fallback
+
+- If the composed context overlay is empty or invalid, the upstream context text is used as a fallback.


### PR DESCRIPTION
## Summary
- document turn increment semantics in the README and module headers
- note the `/continue` draft flow and context fallback behaviour for clarity

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_b_68e7591ce4388329b3295807ded38128